### PR TITLE
Add gas completion

### DIFF
--- a/_gas
+++ b/_gas
@@ -1,0 +1,48 @@
+#compdef gas
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for gas (https://github.com/walle/gas).
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Fredrik Wallgren <fredrik.wallgren@gmail.com>
+#
+# ------------------------------------------------------------------------------
+
+local curcontext="$curcontext" state line cmds ret=1
+
+_arguments -C \
+  '(- 1 *)'{-v,--version}'[display version information]' \
+  '(-h|--help)'{-h,--help}'[show help information]' \
+  '1: :->cmds' \
+  '*: :->args' && ret=0
+
+case "$state" in
+  (cmds)
+    cmds=(
+      "version:Prints Gas's version"
+      "use:Uses author"
+      "show:Shows your current user"
+      "list:Lists your authors"
+      "import:Imports current user to gasconfig"
+      "help:Describe available tasks or one specific task"
+      "delete:Deletes author"
+      "add:Adds author to gasconfig"
+    )
+    _describe -t commands 'gas command' cmds && ret=0
+  ;;
+  (args)
+    case "$line[1]" in
+      (use|delete)
+        _values -S , 'authors' $(cat ~/.gas | sed -n -e 's/^\[\(.*\)\]/\1/p') && ret=0
+      ;;
+    esac
+  ;;
+esac
+
+return ret
+


### PR DESCRIPTION
[Gas](https://github.com/walle/gas) is a small utility used to manage Git authors. It's not popular and may never be. It's up to you if you want to include it.
