### PR TITLE
srm: allow more than one option per word.

### DIFF
--- a/_srm
+++ b/_srm
@@ -45,7 +45,7 @@ fi
 local curcontext=$curcontext state line ret=1
 declare -A opt_args
 
-_arguments -C $opts \
+_arguments -s -S -C $opts \
   $args && ret=0
 
 case $state in


### PR DESCRIPTION
I've updated the srm completion to allow `-abcd` options.
