### PR TITLE
pip install -r file completion fix

### DIFF
--- a/_pip
+++ b/_pip
@@ -68,7 +68,7 @@ case $state in
 
     declare -a requirement
     requirement=(
-      {-r,--requirement=}"[install all the packages listed in the given requirements file]:filename"
+      {-r,--requirement=}"[install all the packages listed in the given requirements file]:filename:_files"
     )
 
     declare -a findlink


### PR DESCRIPTION
Small change to add file completion to the --requirements flag.
