### PR TITLE
Add EditorConfig file denoting indentation style.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://EditorConfig.org
+
+root = true
+
+[_*]
+indent_style = space
+indent_size = 2
+tab_width = 2
+end_of_line = LF


### PR DESCRIPTION
I see that every file in this repo contains a modeline:

``` sh
# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
# vim: ft=zsh sw=2 ts=2 et
```

However, many files still ignore it, and the coding style becomes different for some files and lines then.

This pull request, I believe, will solve this issue largely. This pull request adds a `.editorconfig` file, which is used by [EditorConfig](http://editorconfig.org). EditorConfig is a project that helps developers define and maintain consistent coding styles between different editors and IDEs, and it has supported [many editors](http://editorconfig.org/#download).

Also, EditorConfig has been supported by [many projects](https://github.com/editorconfig/editorconfig/wiki/Projects-Using-EditorConfig), including some famous projects such as [jQuery](https://github.com/jquery/jquery/blob/master/.editorconfig), [Modernizr](https://github.com/Modernizr/Modernizr/blob/master/.editorconfig).

What do you think about it?
