### PR TITLE
optirun: run normal completer instead of files

### DIFF
--- a/_optirun
+++ b/_optirun
@@ -61,7 +61,7 @@ arguments=(
     '(-C --config)'{-C,--config}'[retrieve settings for Bumblebee from FILE]:file:_files'
     '(-l --ldpath)'{-l,--ldpath}'[PATH the libraries like libGL.so are searched in]:file:_files'
     '(-s --socket)'{-s,--socket}'[use FILE for communication with the daemon]:file:_files'
-    '*::arguments: _files'
+    '*::arguments: _normal'
 )
 
 _arguments $arguments


### PR DESCRIPTION
this will complete normal commands (and after that their arguments) after optirun instead of completing files
