### PR TITLE
Move modelines to end of file

### DIFF
--- a/src/_ack
+++ b/src/_ack
@@ -37,9 +37,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _ack() {
@@ -180,3 +177,11 @@ _ack_types_caching_policy() {
 }
 
 _ack "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_adb
+++ b/src/_adb
@@ -38,9 +38,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _adb() {
@@ -410,3 +407,11 @@ _adb_remote_command_default() {
 }
 
 _adb "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_android
+++ b/src/_android
@@ -38,9 +38,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _android() {
@@ -324,3 +321,11 @@ _android_sdk_update_filters() {
 }
 
 _android "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_baselayout
+++ b/src/_baselayout
@@ -42,9 +42,6 @@
 #  * Mamoru Komachi <usata@usata.org>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 #<sys-apps/baselayout-1.12.11.1>
 #
 # Status:
@@ -161,3 +158,11 @@ case "$service" in
 		_rc "$@" && return 0
 	;;
 esac
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_bpython
+++ b/src/_bpython
@@ -34,9 +34,6 @@
 #  * Massimiliano Torromeo <massimiliano.torromeo@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 _arguments -A "-*" \
 	'(-h --help)'{-h,--help}'[Show help message]' \
@@ -45,3 +42,11 @@ _arguments -A "-*" \
 	'(-V --version)'{-V,--version}'[Print version and exit]' \
 	'--config[Use CONFIG instead of default config file]:Config file:_files' \
 	'*: :_files'
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_brew
+++ b/src/_brew
@@ -19,9 +19,6 @@
 #  * Erik Kastner (https://github.com/kastner)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _brew_all_formulae() {
@@ -99,3 +96,11 @@ case "$words[1]" in
     _brew_installed_formulae
     _wanted installed_formulae expl 'installed formulae' compadd -a installed_formulae ;;
 esac
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_bundle
+++ b/src/_bundle
@@ -12,9 +12,6 @@
 #  * Bruno Michel (https://github.com/nono)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 local curcontext="$curcontext" state line _gems _opts ret=1
@@ -83,3 +80,11 @@ case $state in
 esac
 
 return ret
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_cap
+++ b/src/_cap
@@ -12,9 +12,6 @@
 #  * Bruno Michel (https://github.com/nono)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 local curcontext="$curcontext" state line cmds ret=1
@@ -49,3 +46,11 @@ case $state in
 esac
 
 return ret
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_choc
+++ b/src/_choc
@@ -37,9 +37,6 @@
 #  * Nicholas Penree (https://github.com/drudge)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 local curcontext="$curcontext" state line ret=1
 typeset -A opt_args
@@ -53,3 +50,11 @@ _arguments -C \
   '*:script or directory:_files' && ret=0
 
 return ret
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_coffee
+++ b/src/_coffee
@@ -37,9 +37,6 @@
 #  * Mario Fernandez (https://github.com/sirech)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 local curcontext="$curcontext" state line ret=1
 typeset -A opt_args
@@ -64,3 +61,11 @@ _arguments -C \
   '*:script or directory:_files' && ret=0
 
 return ret
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_cpanm
+++ b/src/_cpanm
@@ -14,9 +14,6 @@
 #  * Ryushi (https://github.com/rshhh)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 local arguments curcontext="$curcontext"
@@ -75,3 +72,10 @@ _arguments -s $arguments \
 
 return 1
 
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_debuild
+++ b/src/_debuild
@@ -39,9 +39,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 # FIXME --noconf is only allowed in first position
@@ -58,3 +55,11 @@ _arguments \
   '(-d)-D[force checking of build dependencies]' \
   '--check-dirname-level[how much to check directory names]:level:((0\:never 1\:only\ if\ program\ changes\ directory\ \(default\) 2\:always))' \
   '--check-dirname-regex[Perl regex defining matching directory names, the string PACKAGE will be replaced by the package name (default: '\''PACKAGE(-.+)?'\'')]:regex'
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_dhcpcd
+++ b/src/_dhcpcd
@@ -37,9 +37,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _arguments \
@@ -71,3 +68,11 @@ _arguments \
     '(-R --nodns)'{-R,--nodns}'[don'\''t send DNS information to resolvconf or touch /etc/resolv.conf]' \
     '(-T --test)'{-T,--test}'[on receipt of discover messages, simply print the contents of the DHCP message to the console]' \
     '(-Y --nonis)'{-Y,--nonis}'[don'\''t touch /etc/yp.conf or restart the ypbind service]'
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_ditz
+++ b/src/_ditz
@@ -14,9 +14,6 @@
 #  * technolize (https://github.com/technolize)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 local ME=ditz
@@ -46,3 +43,11 @@ else
           ;;
       esac
 fi
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_emulator
+++ b/src/_emulator
@@ -38,9 +38,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 typeset -A opt_args
@@ -132,3 +129,11 @@ _arguments \
   '-qemu[pass arguments to qemu]:arguments' \
   '-verbose[same as '\''-debug-init'\'']' \
   '*'{-debug,-debug-,-debug-no-}'[enable/disable specific debug messages]:tag'
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_eselect
+++ b/src/_eselect
@@ -43,9 +43,6 @@
 #  * Mamoru Komachi <usata@usata.org>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 #<app-admin/eselect-1.0.11>
 #
 
@@ -200,3 +197,11 @@ _eselect () {
 }
 
 _eselect "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_fab
+++ b/src/_fab
@@ -14,9 +14,6 @@
 #  * Valerii Hiora (https://github.com/vhbit)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 local curcontext=$curcontext state line
@@ -76,3 +73,11 @@ if [[ CURRENT -ge 1 ]]; then
 
     return
 fi
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_gcc-config
+++ b/src/_gcc-config
@@ -42,9 +42,6 @@
 #  * Mamoru Komachi <usata@usata.org>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 #<sys-devel/gcc-config-0.0>
 
 local arguments
@@ -71,3 +68,11 @@ _gcc_profile () {
 }
 
 _arguments $arguments
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_geany
+++ b/src/_geany
@@ -37,9 +37,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _arguments \
@@ -66,3 +63,11 @@ _arguments \
   '(-v --verbose)'{-v,--verbose}'[Be verbose]' \
   '(--display)--display[X display to use]:X display:_x_display' \
   '*: :_files'
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_gem
+++ b/src/_gem
@@ -14,9 +14,6 @@
 #  * Alex Vollmer (https://github.com/alexvollmer)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _gem() {
@@ -454,3 +451,11 @@ _gem_which() {
     "(-g --no-gems-first)"{-g,--no-gems-first}"[search gems before non-gems]" \
     $gem_general_flags && ret=0
 }
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_genlop
+++ b/src/_genlop
@@ -42,9 +42,6 @@
 #  * Mamoru Komachi <usata@usata.org>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 #<app-portage/genlop-0.30.8>
 
 
@@ -148,3 +145,11 @@ _genlop_months() {
 	elif [[ ${month} == 12 ]] then compadd $j $f $m $a $M $ju $J $A $s $o $n $d
 	fi
 }
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_gentoo_packages
+++ b/src/_gentoo_packages
@@ -43,9 +43,6 @@
 #  * Mamoru Komachi <usata@usata.org>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 #Usage: _gentoo_packages installed|available|installed_versions|available_versions|binary|category|useflag|overlays|sets|licenses
 
 # List installed overlays
@@ -222,3 +219,11 @@ _gentoo_packages () {
 }
 
 _gentoo_packages "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_gentoolkit
+++ b/src/_gentoolkit
@@ -43,9 +43,6 @@
 #  * Mamoru Komachi <usata@usata.org>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 #<app-portage/gentoolkit-0.2.4-rc3>
 #
 # Status:
@@ -403,3 +400,11 @@ case "$service" in
         _revdep-rebuild "$@" && return 0
     ;;
 esac
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_git-flow
+++ b/src/_git-flow
@@ -17,9 +17,6 @@
 #  * Zifei Tong (https://github.com/chevalun)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _git-flow ()
@@ -332,3 +329,11 @@ __git_command_successful () {
 }
 
 _git-flow "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_git-pulls
+++ b/src/_git-pulls
@@ -37,9 +37,6 @@
 #  * Julien Nicoulaud (https://github.com/nicoulaj)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _git-pulls() {
@@ -101,3 +98,11 @@ _git-pulls_pull_requests_numbers() {
 }
 
 _git-pulls "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_git-wtf
+++ b/src/_git-wtf
@@ -38,9 +38,6 @@
 #  * Mario Fernandez (https://github.com/sirech)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 _arguments -w -C -s \
     '(--long --short)'{-l,--long}'[include author info and date for each commit]' \
@@ -51,3 +48,11 @@ _arguments -w -C -s \
     '(--relations)'{-r,--relations}'[show relation to features / integration branches]' \
     '(--dump-config)--dump-config[print out current configuration and exit]' \
     '*: :__git_branch_names'
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_github
+++ b/src/_github
@@ -37,9 +37,6 @@
 #  * Julien Nicoulaud (https://github.com/nicoulaj)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _github() {
@@ -265,3 +262,11 @@ _github_network_commits() {
 }
 
 _github "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_google
+++ b/src/_google
@@ -15,9 +15,6 @@
 #  * Ben O'Hara (https://github.com/benohara)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 _google() {
   # init variables
@@ -62,3 +59,11 @@ _google() {
 }
 
 _google "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_gradle
+++ b/src/_gradle
@@ -39,9 +39,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _gradle() {
@@ -128,3 +125,11 @@ _gradle_property_names() {
 }
 
 _gradle "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_heroku
+++ b/src/_heroku
@@ -12,9 +12,6 @@
 #  * Ali B. (http://awhitebox.com)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 local -a _1st_arguments
 _1st_arguments=(
@@ -167,3 +164,11 @@ _arguments \
   $_command_args \
   '(--app)--app[the app name]' \
   &&  return 0
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_jmeter
+++ b/src/_jmeter
@@ -39,9 +39,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _arguments \
@@ -67,3 +64,11 @@ _arguments \
   {-R,--remotestart}'[start these remote servers (overrides remote_hosts)]:remote servers list' \
   {-d,--homedir}'[the JMeter home directory to use]: :_files -/' \
   {-X,--remoteexit}'[exit the remote servers at end of test (non-GUI)]'
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_jmeter-plugins
+++ b/src/_jmeter-plugins
@@ -38,9 +38,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _arguments \
@@ -60,3 +57,11 @@ _arguments \
   '--limit-rows[limit number of points in row]:number of points' \
   '--force-y[force Y axis limit]:limit' \
   '--hide-low-counts[hide points with sample count below limit]:limit'
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_jonas
+++ b/src/_jonas
@@ -37,9 +37,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 typeset -A opt_args
@@ -118,3 +115,11 @@ case "$state" in
 esac
 
 return ret
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_knife
+++ b/src/_knife
@@ -14,9 +14,6 @@
 #  * Frank Louwers (https://github.com/franklouwers)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 # knife has a very special syntax, some example calls are:
@@ -192,3 +189,11 @@ _cookbook_versions() {
 }
 
 _knife "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_language_codes
+++ b/src/_language_codes
@@ -39,9 +39,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 (( $+functions[_language_codes_iso_639_1] )) ||
@@ -268,3 +265,11 @@ _language_codes() {
 
   return ret    
 }
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_layman
+++ b/src/_layman
@@ -42,9 +42,6 @@
 #  * Mamoru Komachi <usata@usata.org>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 #<app-portage/layman-1.1.1>
 #
 
@@ -96,3 +93,11 @@ actions_args=(
 )
 
 _arguments $global_opts[@] $actions_args[@]
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_lein
+++ b/src/_lein
@@ -14,9 +14,6 @@
 #  * technolize (https://github.com/technolize)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 local ret=1 state
@@ -42,3 +39,11 @@ case $state in
 esac
 
 return ret
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_lunar
+++ b/src/_lunar
@@ -14,9 +14,6 @@
 #  * Valodim (https://github.com/Valodim)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 # completion for lunar itself (different name, see below)
@@ -307,3 +304,11 @@ _lunar() {
 }
 
 _lunar "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_manage.py
+++ b/src/_manage.py
@@ -14,9 +14,6 @@
 #  * technolize (https://github.com/technolize)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _managepy-adminindex(){
@@ -238,3 +235,11 @@ _manage.py() {
 }
 
 _manage.py "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_mosh
+++ b/src/_mosh
@@ -14,9 +14,6 @@
 #  * Ben O'Hara (https://github.com/benohara)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 _arguments \
  '--client=:client helper:_command_names -e' \
@@ -28,3 +25,11 @@ _arguments \
  {-p,--port=}':port:_ports' \
  ':remote:_hosts' \
  ':remote command:_command_names -e'
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_mvn
+++ b/src/_mvn
@@ -68,9 +68,6 @@
 #       zstyle ':completion:*:*:mvn:*:warnings' format $'\e[1m -- No matches found --\e[22m'
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _mvn() {
@@ -621,3 +618,11 @@ _mvn_profiles_caching_policy() {
 }
 
 _mvn "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_node
+++ b/src/_node
@@ -38,9 +38,6 @@
 #  * Nicholas Penree (https://github.com/drudge)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 local curcontext="$curcontext" state line ret=1
 typeset -A opt_args
@@ -59,3 +56,11 @@ _arguments -C \
   '*:JS Script:_files -g "*.js"' && ret=0
 
 return ret
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_optirun
+++ b/src/_optirun
@@ -38,9 +38,6 @@
 #  * Christophe-Marie Duquesne <chm.duquesne@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 local curcontext="$curcontext" state line
 typeset -A opt_args
@@ -65,3 +62,11 @@ arguments=(
 )
 
 _arguments $arguments
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_pear
+++ b/src/_pear
@@ -12,9 +12,6 @@
 #  * aki77 (https://github.com/aki77)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _pear () {
@@ -82,3 +79,11 @@ _pear_discovered_channels () {
 }
 
 _pear "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_perf
+++ b/src/_perf
@@ -37,9 +37,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _perf() {
@@ -272,3 +269,11 @@ _perf_cmds() {
 }
 
 _perf "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_periscope
+++ b/src/_periscope
@@ -37,9 +37,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _arguments \
@@ -54,3 +51,11 @@ _arguments \
   '--quiet[run in quiet mode (only show warn and error messages)]' \
   '--debug[set the logging level to debug]' \
   '*: :_files'
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_pgsql_utils
+++ b/src/_pgsql_utils
@@ -16,9 +16,6 @@
 #  * Johann 'Myrkraverk' Oskarsson <johann@2ndquadrant.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _pgsql_get_identity () {
@@ -264,3 +261,11 @@ _pgsql_utils () {
 }
 
 _pgsql_utils "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_pip
+++ b/src/_pip
@@ -14,9 +14,6 @@
 #  * technolize (https://github.com/technolize)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 local ret=1 state
@@ -118,3 +115,11 @@ case $state in
 esac
 
 return ret
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_pkcon
+++ b/src/_pkcon
@@ -34,9 +34,6 @@
 #  * Massimiliano Torromeo <massimiliano.torromeo@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 local -a options
@@ -130,3 +127,11 @@ case "$cmd" in
   ;;
 esac
 return 1
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_play
+++ b/src/_play
@@ -38,9 +38,6 @@
 #  * Mario Fernandez (https://github.com/sirech)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _play() {
@@ -208,3 +205,11 @@ _play_colon_dirs_list() {
 }
 
 _play "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_portage
+++ b/src/_portage
@@ -44,9 +44,6 @@
 #  * Mamoru Komachi <usata@usata.org>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 #<sys-apps/portage-2.1.4.4>
 # TODO: <sys-apps/portage-2.2_aplha*> (sets, some other candies)
 #
@@ -351,3 +348,11 @@ case "$service" in
 		_tbz2tool "$@" && return 0
 	;;
 esac
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_portage_utils
+++ b/src/_portage_utils
@@ -43,9 +43,6 @@
 #  * Mamoru Komachi <usata@usata.org>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 #<app-portage/portage-utils-0.19>
 #
 
@@ -187,3 +184,11 @@ qxpak)
 
 ;;
 esac
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_pygmentize
+++ b/src/_pygmentize
@@ -37,9 +37,6 @@
 #  * Hideo Hattori <hhatto.jp@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 _pygmentize() {
   local context state line
@@ -140,3 +137,11 @@ _pygmentize_caching_policy() {
 }
 
 _pygmentize "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_redis-cli
+++ b/src/_redis-cli
@@ -14,9 +14,6 @@
 #  * Alexandru Totolici (https://github.com/totolici)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 local -a _1st_arguments
@@ -156,3 +153,11 @@ if (( CURRENT == 1 )); then
   _describe -t commands "redis-cli subcommand" _1st_arguments
   return
 fi
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_rvm
+++ b/src/_rvm
@@ -14,9 +14,6 @@
 #  * Bruno Michel (https://github.com/nono)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 local curcontext="$curcontext" state line cmds ret=1
@@ -116,3 +113,11 @@ case $state in
 esac
 
 return ret
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_setup.py
+++ b/src/_setup.py
@@ -12,9 +12,6 @@
 #  * Hideo Hattori (https://github.com/hhatto)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 _setup.py() {
   typeset -A opt_args
@@ -701,3 +698,11 @@ _setuppy_upload_docs() {
 }
 
 _setup.py "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_showoff
+++ b/src/_showoff
@@ -12,9 +12,6 @@
 #  * Bruno Michel (https://github.com/nono)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 local curcontext="$curcontext" state line cmds ret=1
@@ -77,3 +74,11 @@ case $state in
 esac
 
 return ret
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_smartmontools
+++ b/src/_smartmontools
@@ -34,9 +34,6 @@
 #  * Massimiliano Torromeo <massimiliano.torromeo@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 _smartctl() {
 	local context state line expl
@@ -108,3 +105,11 @@ _smartmontools() {
 }
 
 _smartmontools "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_ssh-copy-id
+++ b/src/_ssh-copy-id
@@ -37,9 +37,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 # FIXME This completes "user@host" and not "[user@]host" ("user@" is optional),
@@ -48,3 +45,11 @@
 _arguments -A "-*" \
   '-i+[use identity file]:SSH identity file:_files' \
   '1: :_user_at_host'
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_subliminal
+++ b/src/_subliminal
@@ -37,9 +37,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _arguments \
@@ -56,3 +53,11 @@ _arguments \
   '(--no-cache-dir)--cache-dir[cache directory to use]: :_files -/' \
   '(--cache-dir)--no-cache-dir[do not use cache directory]' \
   '*: :_files'
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_symfony
+++ b/src/_symfony
@@ -12,9 +12,6 @@
 #  * aki77 (https://github.com/aki77)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _symfony () {
@@ -449,3 +446,11 @@ _get_sf_cache_var () {
 }
 
 _symfony "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_teamocil
+++ b/src/_teamocil
@@ -38,9 +38,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _arguments \
@@ -48,3 +45,11 @@ _arguments \
   '--layout[specify a custom file path to a YAML layout file]:teamocil layout file:_files -g "*.yml"' \
   '--edit[open the layout file (whether or not --layout is used) with $EDITOR]' \
   '1:teamocil layout:_files -W ~/.teamocil -g "*.yml(:r)"'
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_thor
+++ b/src/_thor
@@ -14,10 +14,15 @@
 #  * Andrew Hodges (https://github.com/betawaffle)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 # FIXME This should be rewritten using up-to-date ZSH completion API.
 compadd `thor list | grep thor | cut -d " " -f 2`
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_tmuxinator
+++ b/src/_tmuxinator
@@ -15,9 +15,6 @@
 #  * Ben O'Hara (https://github.com/benohara)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 _tmuxinator() {
   local -a projects
@@ -53,3 +50,11 @@ _tmuxinator() {
 }
 
 _tmuxinator
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_vagrant
+++ b/src/_vagrant
@@ -14,9 +14,6 @@
 #  * Nikita Fedyashev (https://github.com/nfedyashev)
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 local -a _1st_arguments
@@ -125,3 +122,11 @@ case $state in
     esac
   ;;
 esac
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_virtualbox
+++ b/src/_virtualbox
@@ -35,9 +35,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 _vboxmachines() {
@@ -310,3 +307,11 @@ _virtualbox() {
 }
 
 _virtualbox "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/src/_vpnc
+++ b/src/_vpnc
@@ -37,9 +37,6 @@
 #  * Julien Nicoulaud <julien.nicoulaud@gmail.com>
 #
 # ------------------------------------------------------------------------------
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# ------------------------------------------------------------------------------
 
 
 (( $+functions[_vpnc-connect] )) ||
@@ -200,3 +197,11 @@ case $service in
   vpnc|vpnc-connect) _call_function ret _vpnc-connect && return ret ;;
   vpnc-disconnect)   _call_function ret _vpnc-disconnect && return ret ;;
 esac
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et


### PR DESCRIPTION
Having a vim modeline or emacs local variable line somewhere in the
middle of the file isn't really helpful.  By default, vim will only
check the first and last 5 lines of a file for a modeline (assuming the
modeline option is enabled).  Emacs is even more strict about the type
of local variable line that was in use, it will only check the first
line of the file or the second line if the first line specifies a script
interpreter (which isn't the case here).

Move the vim modeline to the end of the file so that it can actually be
found by vim but is out of the way for editing.  For emacs more work is
required, convert that to the more verbose Local Variables syntax which
emacs will look for starting 3000 characters from the end of the file.

Also there is no zsh mode for emacs (according to
zsh-users/zsh-completions#75), use the "Shell-Script" mode instead.
This seems to automatically detect that the files are for zsh.

I'm not an emacs user, so I haven't tested that portion much.  But, this
does at least improve the syntax highlighting there.
