### PR TITLE
Complete argument for rvm --patch option

### DIFF
--- a/src/_rvm
+++ b/src/_rvm
@@ -23,12 +23,13 @@ _arguments -C \
   '--bin[path for binaries to be placed (~/.rvm/bin/)]:path:_files' \
   '--source[src directory to use (~/.rvm/src/)]:path:_files' \
   '--archives[directory for downladed files (~/.rvm/archives/)]:path:_files' \
+  '-n[Name for new ruby install]:name:' \
   '-S[Specify a script file to attempt to load and run (rubydo)]:file:_files' \
   '-e[Execute code from the command line]:code' \
   '-G[root gem path to use]:path:_files' \
   '--gems[Used to set the gems_flag, use with remove to remove gems]' \
   '--archive[Used to set the archive_flag, use with remove to remove archive]' \
-  '--patch[With MRI Rubies you may specify one or more full paths to patches]' \
+  '--patch[With MRI Rubies you may specify one or more full paths to patches]:paths:->patches' \
   '(-C --configure)'{-C,--configure}'=[custom configure options]' \
   '--nice[process niceness (for slow computers, default 0)]:number' \
   '--ree-options[Options passed directly to ree ./installer on the command line]:options' \
@@ -47,6 +48,12 @@ _arguments -C \
   '*: :->args' && ret=0
 
 case $state in
+
+  patches)
+    compset -P '*,'
+    compset -S ',*'
+    _files -q -S ,
+    ;;
 
   cmds)
 


### PR DESCRIPTION
The rvm --patch option takes an argument that is one or more file names
separated by commas.
