### PR TITLE
Fix completion of “vagrant ssh-config”

### DIFF
--- a/src/_vagrant
+++ b/src/_vagrant
@@ -28,7 +28,7 @@ _1st_arguments=(
     'reload:Reload the vagrant environment'
     'resume:Resumes a suspend vagrant environment'
     'ssh:SSH into the currently running environment'
-    'ssh_config:outputs .ssh/config valid syntax for connecting to this environment via ssh.'
+    'ssh-config:outputs .ssh/config valid syntax for connecting to this environment via ssh.'
     'status:Shows the status of the current Vagrant environment.'
     'suspend:Suspends the currently running vagrant environment'
     'up:Creates the vagrant environment'


### PR DESCRIPTION
The completion for vagrant incorrectly listed “ssh_config” as a command. This should be “ssh-config” – at least on Vagrant version 1.0.3.
