### PR TITLE
Use $ACKRC if set, otherwise use $HOME/.ackrc

### DIFF
--- a/src/_ack
+++ b/src/_ack
@@ -166,7 +166,7 @@ _ack() {
 _ack_types_caching_policy() {
 
   # Rebuild if ackrc more recent than cache.
-  [[ -f $HOME/.ackrc && $$HOME/.ackrc -nt "$1" ]] && return 0
+  [[ -f ${ACKRC:-$HOME/.ackrc} && ${ACKRC:-$HOME/.ackrc} -nt "$1" ]] && return 0
 
   # Rebuild if cache is older than one week.  
   local -a oldp


### PR DESCRIPTION
The $ACKRC environmental variable allows a user to specify a path to his or her Ack config file. If not set, Ack looks for a file in the default location (~/.ackrc).

This update makes ack completion follow that same behavior.
