### PR TITLE
Fix issues relative link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ zsh-completions
 
 Status
 ------
-See [issues](zsh-completions/issues) for details on each completion definition.
+See [issues](https://github.com/zsh-users/zsh-completions/issues) for details on each completion definition.
 
 
 Usage


### PR DESCRIPTION
The issues link was broken in the readme. It was previously a workaround relative link which were broken by a [recent update](https://github.com/blog/1395-relative-links-in-markup-files) to GitHub.

It's now an absolute link which works better for the repository issues. If someone were to fork the repo now, their readme would still link back to the main project's issues.
