### PR TITLE
Updated ssh-copy-id completion

### DIFF
--- a/src/_ssh-copy-id
+++ b/src/_ssh-copy-id
@@ -44,6 +44,10 @@
 
 _arguments -A "-*" \
   '-i+[use identity file]:SSH identity file:_files' \
+  '-n+[do a dry-run]' \
+  '-h+[print usage summary]' \
+  '-p+[specifiy custom port]' \
+  '-o+[additional ssh option]' \
   '1: :_user_at_host'
 
 # Local Variables:


### PR DESCRIPTION
Added some missing flags:
- -n
- -h
- -p
- -o

See ssh-copy-id(1) for more informations about those flags.
