### PR TITLE
Add zsh-completions.plugin.zsh file for easy installation with oh-my-zsh

### DIFF
--- a/zsh-completions.plugin.zsh
+++ b/zsh-completions.plugin.zsh
@@ -1,0 +1,5 @@
+#!/usr/bin/env zsh
+
+fpath+="$(dirname $0)/src"
+
+compinit


### PR DESCRIPTION
Clone zsh-completions to ~/.oh-my-zsh/custom/plugins, and add

```
plugins+=zsh-completions
```

should be able to activate this as an oh-my-zsh plugin.
