### PR TITLE
reinstall tab completion which was added to homebrew

### DIFF
--- a/src/_brew
+++ b/src/_brew
@@ -59,6 +59,7 @@ _1st_arguments=(
   'options:display install options specific to formula'
   'outdated:list formulae for which a newer version is available'
   'prune:remove dead links'
+  'reinstall:install a formula anew; re-using its current options'
   'remove:remove a formula'
   'search:search for a formula (/regex/ or string)'
   'server:start a local web app that lets you browse formulae (requires Sinatra)'
@@ -114,7 +115,7 @@ case "$words[1]" in
         _brew_installed_formulae
         _wanted installed_formulae expl 'installed formulae' compadd -a installed_formulae
       fi ;;
-  install|home|homepage|log|info|abv|uses|cat|deps|edit|options)
+  install|reinstall|home|homepage|log|info|abv|uses|cat|deps|edit|options)
     _brew_all_formulae
     _wanted formulae expl 'all formulae' compadd -a formulae ;;
   remove|rm|uninstall|unlink|cleanup|link|ln|pin|unpin|test)


### PR DESCRIPTION
for users who install the zsh completion file. Already exists in homebrew.
