### PR TITLE
Fix matching for vm names im Vagrant file when using dashes or underscor...

### DIFF
--- a/src/_vagrant
+++ b/src/_vagrant
@@ -76,7 +76,7 @@ __plugin_list ()
 
 __vm_list ()
 {
-    _wanted application expl 'command' compadd $(command grep Vagrantfile -oe '^[^#]*\.vm\.define * "\?''\?\([a-zA-Z0-9\-]\+\)"\?''\?' | awk '{print $NF}' | sed 's/''//g'|sed 's/\"//g' )
+    _wanted application expl 'command' compadd $(command grep Vagrantfile -oe '^[^#]*\.vm\.define * "\?''\?\([a-zA-Z0-9\-]\+\)"\?''\?' 2>/dev/null | awk '{print $NF}' | sed 's/''//g'|sed 's/\"//g' )
 }
 
 __vagrant-box ()


### PR DESCRIPTION
This fixes a problem when quoting vm names in the vagrant file to use dashes/underscores.

Maybe a more elegant way? but does the job.
