### PR TITLE
Fix vagrant vm name matching

### DIFF
--- a/src/_vagrant
+++ b/src/_vagrant
@@ -76,7 +76,7 @@ __plugin_list ()
 
 __vm_list ()
 {
-    _wanted application expl 'command' compadd $(command grep Vagrantfile -oe '^[^#]*\.vm\.define * "\?''\?\([a-zA-Z0-9\-]\+\)"\?''\?' 2>/dev/null | awk '{print $NF}' | sed 's/''//g'|sed 's/\"//g' )
+    _wanted application expl 'command' compadd $(command grep Vagrantfile -oe '^[^#]*\.vm\.define * ['\''":]\?\([a-zA-Z0-9\-]\+\)['\''"]\?' 2>/dev/null | awk '{print $NF}' | sed 's/'\''//g'|sed 's/\"//g'|sed 's/^://' )
 }
 
 __vagrant-box ()


### PR DESCRIPTION
- escaping of single quotes was wrong (at least didn't work for me in both mac and linux)
- match older vagrant files which uses keywords as vm names.
