### PR TITLE
Fix Gentoo overlay in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Usage
 #### Using packages
 
 * Arch Linux: [AUR/zsh-completions](https://aur.archlinux.org/packages.php?ID=54111) / [AUR/zsh-completions-git](https://aur.archlinux.org/packages.php?ID=51001)
-* Gentoo: [scrill overlay](http://gpo.zugaina.org/app-shells/zsh-completions)
+* Gentoo: [sunrise overlay](http://gpo.zugaina.org/app-shells/zsh-completions)
 * Mac OS: [Homebrew](https://github.com/mxcl/homebrew/blob/master/Library/Formula/zsh-completions.rb)
 * Debian based distributions (Debian/Ubuntu/Linux Mint...): Packager needed, please get in touch !
 * RPM based distributions (Fedora/RHEL/CentOS...): Packager needed, please get in touch !


### PR DESCRIPTION
Fix a recommended overlay in README as sunrise overlay is much more "official" and a package there is actively maintained and tested.
