### PR TITLE
Update _yaourt

### DIFF
--- a/src/_yaourt
+++ b/src/_yaourt
@@ -186,7 +186,7 @@ _yaourt_completions_repositories() {
 # $cmd must be declared by calling function
 _yaourt_get_command() {
     # this is mostly nicked from _perforce
-    cmd=( "pacman" )
+    cmd=$(grep ^PACMAN= /etc/yaourtrc | cut -c8- || echo "pacman")
     integer i
     for (( i = 2; i < CURRENT - 1; i++ )); do
         if [[ ${words[i]} = "--config" || ${words[i]} = "--root" ]]; then


### PR DESCRIPTION
I have the next function in .zshrc:

```
pacman () { 
  /usr/bin/sudo /usr/bin/pacman $* && echo "$*" | grep -q "S\|R" && rehash
}
```

And I have the next line in /etc/yaourtrc:

```
PACMAN="/usr/bin/pacman"
```

But if I try to get autocomplite for `yaourt -Qs` (for example) it requires the sudo password. With this patch path to `pacman` will be read from the configuration file and this command will not require the password.
