### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Usage
 
 #### Using packages
 
-* Arch Linux: [AUR/zsh-completions](https://aur.archlinux.org/packages.php?ID=54111) / [AUR/zsh-completions-git](https://aur.archlinux.org/packages.php?ID=51001)
+* Arch Linux: [community/zsh-completions](https://www.archlinux.org/packages/zsh-completions) / [AUR/zsh-completions-git](https://aur.archlinux.org/packages/zsh-completions-git/)
 * Gentoo: [scrill overlay](http://gpo.zugaina.org/app-shells/zsh-completions)
 * Mac OS: [Homebrew](https://github.com/mxcl/homebrew/blob/master/Library/Formula/zsh-completions.rb)
 * Debian based distributions (Debian/Ubuntu/Linux Mint...): Packager needed, please get in touch !


### PR DESCRIPTION
Edited links to Archlinux packages (the link to `zsh-completion-git` is out-of-date, and `zsh-completion` is now available in [community])
