### PR TITLE
Add watch completion

### DIFF
--- a/src/_watch
+++ b/src/_watch
@@ -1,0 +1,55 @@
+#compdef watch
+# ------------------------------------------------------------------------------
+# Copyright (c) 2014 Github zsh-users - http://github.com/zsh-users
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the zsh-users nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL ZSH-USERS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for watch (https://gitorious.org/procps/procps).
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Nicolas Iooss (https://github.com/fishilico)
+#
+# ------------------------------------------------------------------------------
+
+_arguments \
+  '(-b --beep)'{-b,--beep}'[beep if command has a non-zero exit]' \
+  '(-c --color)'{-c,--color}'[interpret ANSI color sequences]' \
+  '(-d --differences)'{-d,--differences}'[highlight changes between updates]' \
+  '(-d --differences)--differences=permanent[highlight changes since the first iteration]' \
+  '(-e --errexit)'{-e,--errexit}'[exit if command has a non-zero exit]' \
+  '(-g --chgexit)'{-g,--chgexit}'[exit when output from command changes]' \
+  '(-n --interval)'{-n,--interval}'[seconds to wait between updates]:interval:' \
+  '(-p --precise)'{-p,--precise}'[attempt run command in precise intervals]' \
+  '(-t --no-title)'{-t,--no-title}'[turn off showing the header]' \
+  '(-x --exec)'{-x,--exec}'[pass command to exec instead of "sh -c"]' \
+  '(-h --help)'{-h,--help}'[display help information]' \
+  '(-v --version)'{-v,--version}'[output version information]' \
+  '(-):command: _command_names -e' \
+  '*::arguments: _normal'


### PR DESCRIPTION
Hello, I'm using `watch` (from procps project, https://gitorious.org/procps/procps/) to execute a program periodically and see its output. This program hasn't got any zsh completion script that I'm aware of so I've written one a few days ago. This is my first completion script and it is highly likely that I missed something when I wrote it, so please review it carefully before merging.

With this new script there is something which doesn't work as I would expect but I don't know whether it's due to my script or to zsh internals. When hitting TAB after `watch -n 1` zsh  tries to complete "external command" as expected, but when hitting TAB after `watch -n1` (no space between "n" and "1"), zsh tries to complete "file" instead. How could this strange behavior be fixed?

For your information, I've used parts of the `_sudo` script to copy the behavior "complete a command after the options" (https://github.com/zsh-users/zsh/blob/master/Completion/Unix/Command/_sudo) and used `watch --help` and `man watch` to list the optional parameters.
