### PR TITLE
Fixed pass completion to handle when .password-store is a symlink

### DIFF
--- a/src/_pass
+++ b/src/_pass
@@ -98,7 +98,7 @@ _pass_cmd_show () {
 _pass_complete_entries_helper () {
 	local IFS=$'\n'
 	local prefix="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
-	_values -C 'passwords' $(find "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print | sed -e "s#${prefix}.##" -e 's#\.gpg##' | sort)
+	_values -C 'passwords' $(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print | sed -e "s#${prefix}.##" -e 's#\.gpg##' | sort)
 }
 
 _pass_complete_entries_with_subdirs () {


### PR DESCRIPTION
Tab completion fails for "pass" when .password-store is a symlink (common in many git-based config setups).  This patch adds the "-L" switch to **find** to allow the completion to work across symlinks.
