### PR TITLE
[Vagrant] update box list completion

### DIFF
--- a/src/_vagrant
+++ b/src/_vagrant
@@ -66,7 +66,7 @@ __task_list ()
 
 __box_list ()
 {
-    _wanted application expl 'command' compadd $(command ls -1 $HOME/.vagrant/boxes 2>/dev/null| sed -e 's/ /\\ /g')
+    _wanted application expl 'command' compadd $(command ls -1  ${VAGRANT_HOME:-$HOME/.vagrant.d}/boxes 2>/dev/null| sed -e 's/ /\\ /g')
 }
 
 __plugin_list ()


### PR DESCRIPTION
relocate `$HOME/.vagrant` to `$HOME/.vagrant.d` and use `$VAGRANT_HOME` if defined
