### PR TITLE
[Vagrant] Add pattern of underscore to vm_list

### DIFF
--- a/src/_vagrant
+++ b/src/_vagrant
@@ -76,7 +76,7 @@ __plugin_list ()
 
 __vm_list ()
 {
-    _wanted application expl 'command' compadd $(command grep Vagrantfile -oe '^[^#]*\.vm\.define * ['\''":]\?\([a-zA-Z0-9\-]\+\)['\''"]\?' 2>/dev/null | awk '{print $NF}' | sed 's/'\''//g'|sed 's/\"//g'|sed 's/^://' )
+    _wanted application expl 'command' compadd $(command grep Vagrantfile -oe '^[^#]*\.vm\.define * ['\''":]\?\([a-zA-Z0-9\-_]\+\)['\''"]\?' 2>/dev/null | awk '{print $NF}' | sed 's/'\''//g'|sed 's/\"//g'|sed 's/^://' )
 }
 
 __vagrant-box ()


### PR DESCRIPTION
Enable to grep VM name like `foo_bar`

``` rb
config.vm.define :foo_bar do |c|
  ...
end
```
