### PR TITLE
Add ag flags based on version 0.24.0.

### DIFF
--- a/src/_ag
+++ b/src/_ag
@@ -23,6 +23,12 @@ _ag() {
   zstyle -s ":completion:${curcontext}:" cache-policy update_policy
   [[ -z "$update_policy" ]] && zstyle ":completion:${curcontext}:" cache-policy _ag_types_caching_policy
 
+  if ( [[ ${+_ag_types} -eq 0 ]] || _cache_invalid "ag_types" ) && ! _retrieve_cache "ag_types"; then
+    _ag_types=( ${(f)"$(ag --list-file-types | awk ' /--/ { VAR=$1; gsub(/--/, "", VAR); \
+      getline; gsub(/^ */, ""); printf "%s %s\n", VAR, $0 } ')"} )
+    [[ $#_ag_types -gt 0 ]] && _store_cache 'ag_types' _ag_types
+  fi
+
   _arguments -C \
     '(- 1 *)--version[display version and copyright information]' \
     '(- 1 *)--help[print a short help statement]' \
@@ -33,6 +39,9 @@ _ag() {
     '(-B --before)'{-B,--before}'[Print lines after match. Defaults to 2.]:LINES' \
     '(--nobreak --break)'{--nobreak,--break}'[Print a newline between matches in different files. Enabled by default.]' \
     '(--nocolor --color)'{--nocolor,--color}'[Print color codes in results. Enabled by default.]' \
+    '(--color-line-number)--color-line-number[Color codes for line numbers. Defaults to 1;33.]' \
+    '(--color-match)--color-match[Color codes for result match numbers. Defaults to 30;43.]' \
+    '(--color-path)--color-path[Color codes for path names. Defaults to 1;32.]' \
     '(--column)--column[Print column numbers in results.]' \
     '(-C --context)'{-C,--context}'[Print lines before and after matches. Defaults to 2.]:LINES' \
     '(-D --debug)'{-D,--debug}'[Ridiculous debugging. Probably not useful.]' \
@@ -45,21 +54,28 @@ _ag() {
     '(--hidden)--hidden[Search hidden files. This option obeys ignore files.]' \
     '(-i --ignore-case)'{-i,--ignore-case}'[Match case insensitively]:PATTERN' \
     '(--ignore)--ignore[Ignore files/directories matching this pattern. Literal file and directory names are also allowed.]' \
+    '(--ignore-dir)--ignore-dir[Alias for --ignore for compatability with ack.]' \
     '(-l --files-with-matches)'{-l,--files-with-matches}'[Only print filenames containing matches, not matching lines.]' \
     '(-L --files-without-matches)'{-L,--files-without-matches}"[Only print filenames that don't contain matches.]" \
+    '(--list-file-types)--list-file-types[List supported filetypes to search.]' \
     '(-m --max-count)'{-m,--max-count}'[Skip the rest of a file after NUM matches. Default is 10,000.]:NUM' \
+    "(--no-numbers)--no-numbers[Don't show line numbers.]" \
     '(-p --path-to-agignore)'{-p,--path-to-agignore}'[Provide a path to a specific .agignore file]:STRING' \
+    '(--pager --nopager)'{--pager,--nopager}'[Display results with PAGER. Disabled by default.]' \
     '(--print-long-lines)--print-long-lines[Print matches on very long lines (> 2k characters by default)]' \
     '(-Q --literal)'{-Q,--literal}'[Do not parse PATTERN as a regular expression. Try to match it literally.]' \
     '(-s --case-sensitive)'{-s,--case-sensitive}'[Match case sensitively. Enabled by default.]' \
     '(-S --smart-case)'{-S,--smart-case}'[Match case sensitively if there are any uppercase letters in PATTERN, or case insensitively otherwise.]' \
     '(--search-binary)--search-binary[Search binary files for matches.]' \
+    '(--silent)--silent[Suppress all log messages, including errors.]' \
     '(--stats)--stats[Print stats (files scanned, time taken, etc)]' \
     '(-t --all-text)'{-t,--all-text}"[Search all text files. This doesn't include hidden files.]" \
     '(-u --unrestricted)'{-u,--unrestricted}'[Search *all* files. This ignores .agignore, .gitignore, etc. It searches binary and hidden files as well.]' \
     '(-U --skip-vcs-ignores)'{-U,--skip-vcs-ignores}'[Ignore VCS ignore files (.gitigore, .hgignore, svn:ignore), but still use .agignore.]' \
     '(-v --invert-match)'{-v,--invert-match}'[invert match]' \
     '(-w --word-regexp)'{-w,--word-regexp}'[Only match whole words.]' \
+    '(-z --search-zip)'{-z,--search-zip}'[Search contents of compressed file.]' \
+    {'--','--no'}${_ag_types/ ##/\[}']' \
     '1: :->patterns' \
     '*: :_files' \
     && ret=0
@@ -78,7 +94,7 @@ _ag_types_caching_policy() {
   # Rebuild if .agignore more recent than cache.
   [[ -f $HOME/.agignore && $$HOME/.agignore -nt "$1" ]] && return 0
 
-  # Rebuild if cache is older than one week.  
+  # Rebuild if cache is older than one week.
   local -a oldp
   oldp=( "$1"(Nmw+1) )
   (( $#oldp )) && return 0


### PR DESCRIPTION
Hi, just started using zsh-completions and zsh for that matter. I noticed the ag completion is quite out of date and I use that a lot. I've made the necessary changes and tried to respect existing standards. Before merging this, a few questions.

1) I compared this with _ack, and noticed that file has descriptions mainly starting lower case and not ending in periods. In this file, seems that the majority of lines are capitalized with periods. Should _ag descriptions be converted to match _ack? Regarding

2) In the _ack code I noticed this snippet:

``` sh
  unset _ack_raw_types
  if ( [[ ${+_ack_raw_types} -eq 0 ]] || _cache_invalid "ack-grep" ) && ! _retrieve_cache "ack-grep"; then

    _ack_raw_types=(${(S)${(S)${(f)${${"$(_call_program types $words[1] --help=types)"}#*--\[no\]}}%; first line matches \/*\/}#*no\]})
    [[ $#_ack_raw_types -gt 0 ]] && _store_cache "ack-grep" _ack_raw_types
  fi  
```

a) Why is _ack_raw_types always unset? That seems to make the first test -eq 0 on the if useless as it always fails. Left over test code maybe?
b) Why is _call_program used? Not sure I quite understand this zsh function, its description is brief in docs. Is it similar to `command` forcing a lookup? Why not use `command`?
