### PR TITLE
Various virsh fixes

### DIFF
--- a/src/_virsh
+++ b/src/_virsh
@@ -40,7 +40,7 @@ local -a args reply
 
 function _virsh-domains() {
   local -a out
-  out=( ${${${${(f)"$(virsh list "$@")"}:#(---| Id)*}## #[0-9]## ##}%% *} )
+  out=( ${${${${(f)"$(virsh list "$@")"}:#(---| Id)*}## #[0-9-]## ##}%% *} )
   _describe -t domains "${${1#--}:-running} domains" out
   return $?
 }


### PR DESCRIPTION
Two fixes:
1. Complete domains with older versions of virsh not supporting `--name`
2. Use `_describe` instead of low-level `compadd`
