### PR TITLE
call vagrant directly to get hostnames/box names

### DIFF
--- a/src/_vagrant
+++ b/src/_vagrant
@@ -16,26 +16,33 @@
 #
 # ------------------------------------------------------------------------------
 
+# vagrant zsh completion
 
 local -a _1st_arguments
 _1st_arguments=(
     'box:Box commands'
+    'connect:Connects to a shared, remote Vagrant environment'
     'destroy:Destroys the vagrant environment'
-    'global-status:Shows the status of the global Vagrant environment.'
+    'docker-logs:Shows Docker logs'
+    'docker-run:Run one-off commands against a Docker container'
+    'global-status:Reports the status of all active Vagrant environments on the system'
     'halt:Halts the currently running vagrant environment'
     'help:[TASK] Describe available tasks or one specific task'
     'init:[box_name] [box_url] Initializes current folder for Vagrant usage'
+    'login:Authenticates against a Vagrant Cloud server to access protected boxes'
     'package:Packages a vagrant environment for distribution'
     'plugin:Manage plugins'
     'provision:Run the provisioner'
     'reload:Reload the vagrant environment'
     'resume:Resumes a suspend vagrant environment'
+    'share:Shares the Vagrant environment and allows remote access'
     'ssh:SSH into the currently running environment'
-    'ssh-config:outputs .ssh/config valid syntax for connecting to this environment via ssh.'
-    'status:Shows the status of the current Vagrant environment.'
+    'ssh-config:outputs .ssh/config valid syntax for connecting to this environment via ssh'
+    'status:Shows the status of the current Vagrant environment'
     'suspend:Suspends the currently running vagrant environment'
     'up:Creates the vagrant environment'
-    'version:Prints the Vagrant version information'
+    'version:Prints the currently installed Vagrant version and checks for new updates'
+    '--version:Prints the Vagrant version information'
 )
 
 local -a _box_arguments
@@ -59,7 +66,7 @@ _plugin_arguments=(
 __task_list ()
 {
     local expl
-    local -a tasks
+    declare -a tasks
 
     tasks=(box destroy global-status halt init package plugin provision \
            reload resume ssh ssh_config status suspend up version)
@@ -131,7 +138,7 @@ __vm_list ()
 __vagrant-box ()
 {
     local curcontext="$curcontext" state line
-    local -A opt_args
+    typeset -A opt_args
 
     _arguments -C \
         ':command:->command' \


### PR DESCRIPTION
-no longer makes the assumption that files are parseable, just call vagrant
    directly to get the information for status|box list
-cache results until Vagrantfile changes
