### PR TITLE
[Add] Envoy completion & symfony console enhancements

### DIFF
--- a/src/_console
+++ b/src/_console
@@ -38,15 +38,16 @@
 #
 # ------------------------------------------------------------------------------
 
+_find_console () {
+     echo "php $(find . -maxdepth 2 -mindepth 1 -name 'console' -type f | head -n 1)"
+}
 
 _console_get_command_list () {
-    php console --no-ansi | sed "1,/Available commands/d" | awk '/ [a-z]+/ { print $1 }'
+    `_find_console` --no-ansi | sed "1,/Available commands/d" | awk '/ [a-z]+/ { print $1 }'
 }
 
 _console () {
-    if [ -f console ]; then
-        compadd `_console_get_command_list`
-    fi
+    compadd `_console_get_command_list`
 }
 
 compdef _console php console

--- a/src/_envoy
+++ b/src/_envoy
@@ -1,0 +1,67 @@
+#compdef envoy
+# ------------------------------------------------------------------------------
+# Copyright (c) 2011 Github zsh-users - http://github.com/zsh-users
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# * Neither the name of the zsh-users nor the
+# names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL ZSH-USERS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for envoy (https://github.com/laravel/envoy).
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * loranger (https://github.com/loranger)
+#
+# ------------------------------------------------------------------------------
+
+
+_envoy_get_command_list () {
+    envoy --no-ansi | sed "1,/Available commands/d" | awk '/^  [a-z]+/ { print $1 }'
+}
+
+_envoy_get_option_list () {
+    envoy --no-ansi | sed "1,/Options/d" | awk '/^  --[a-z]+/ { print $1 }'
+}
+
+_envoy_get_help_list () {
+    envoy help $1 --no-ansi | sed "1,/Options/d" | awk '/^  --[a-z]+/ { print $1 }'
+}
+
+_envoy_get_task_list () {
+    if [ $1 = 'run' ] && [ -f Envoy.blade.php ]; then
+        perl -nE "say $& if /(task|macro)\('\K[^']+/g" Envoy.blade.php
+    fi
+}
+
+_envoy () {
+    _arguments : \
+        `_envoy_get_option_list` \
+        ":command:compadd `_envoy_get_command_list`" \
+        ":task:compadd `_envoy_get_task_list $words[$CURRENT-1]`"
+}
+
+compdef _envoy envoy

--- a/src/_homestead
+++ b/src/_homestead
@@ -1,0 +1,53 @@
+#compdef homestead
+# ------------------------------------------------------------------------------
+# Copyright (c) 2011 Github zsh-users - http://github.com/zsh-users
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# * Neither the name of the zsh-users nor the
+# names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL ZSH-USERS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for homestead (http://laravel.com/docs/homestead).
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * loranger (https://github.com/loranger)
+#
+# ------------------------------------------------------------------------------
+
+
+_homestead_get_command_list () {
+    homestead --no-ansi | sed "1,/Available commands/d" | awk '/ [a-z]+/ { print $1 }'
+}
+
+_homestead () {
+    if [ -f homestead ]; then
+        compadd `_homestead_get_command_list`
+    fi
+}
+
+compdef _homestead php homestead
+compdef _homestead homestead


### PR DESCRIPTION
- Completion for [Envoy](https://github.com/laravel/envoy) deployment tool.
- Allow to invoke console from project instead of `app/` directory