### PR TITLE
added completion for knife diff

### DIFF
--- a/src/_knife
+++ b/src/_knife
@@ -44,7 +44,7 @@ _knife() {
   
   case $state in
   knifecmd)
-    compadd -Q "$@" bootstrap client configure cookbook "cookbook site" "data bag" environment user exec index node recipe role search ssh status windows $cloudproviders
+    compadd -Q "$@" bootstrap client configure cookbook "cookbook site" "data bag" diff environment user exec index node recipe role search ssh status windows $cloudproviders
   ;;
   knifesubcmd)
     case $words[2] in
@@ -59,6 +59,9 @@ _knife() {
     ;;
     cookbook)
       compadd -Q "$@" test list create download delete "metadata from" show "bulk delete" metadata upload
+    ;;
+    diff)
+      _arguments '*:file or directory:_files -g "*.(rb|json)"'
     ;;
     environment)
       compadd -Q "$@" create delete edit "from file" list show


### PR DESCRIPTION
Not sure if this was omitted on purpose, but I use it all the time. Adds completions for knife diff

`knife diff {directory/file}`