### PR TITLE
Small fixes for adb completion

### DIFF
--- a/src/_adb
+++ b/src/_adb
@@ -83,7 +83,7 @@ _adb() {
         ;;
         (sideload)
           _arguments \
-            '1:local directory:_files -/' \
+            '1:archive:_files -g "*.zip(-.)"' \
           && ret=0
         ;;
         (sync)

--- a/src/_adb
+++ b/src/_adb
@@ -71,7 +71,7 @@ _adb() {
         ;;
         (push)
           _arguments \
-            '1:local directory:_files -/' \
+            '1:files:_files' \
             '2: :_adb_remote_files -/' \
           && ret=0
         ;;

--- a/src/_adb
+++ b/src/_adb
@@ -199,6 +199,7 @@ _adb_device_cmds() {
   local commands; commands=(
     'push:copy file/dir to device'
     'pull:copy file/dir from device'
+    'sideload:push an update using sideload'
     'sync:copy host->device only if changed'
     'shell:run remote shell interactively or command'
     'emu:run emulator console command'


### PR DESCRIPTION
Make `sideload` a possible completion as a command (it was missing). Also make it complete ZIP archives since it is its only use. Also change the completion for push to complete any file since regular files can be pushed too.