### PR TITLE
Add simple completion function for nload(1).

### DIFF
--- a/src/_nload
+++ b/src/_nload
@@ -1,0 +1,70 @@
+#compdef nload
+# ------------------------------------------------------------------------------
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# For more information, please refer to <http://unlicense.org/>
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for nload from http://www.roland-riegel.de/nload/
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Lucas Hoffmann
+#
+# ------------------------------------------------------------------------------
+
+local -a units
+units=(
+  'b\:bit'
+  'k\:kbit'
+  'm\:Mbit'
+  'g\:Gbit'
+  'B\:byte'
+  'K\:kbyte'
+  'M\:Mbyte'
+  'G\:Gbyte'
+)
+local -a units2
+units2=${units/%/\/s}
+local -a auto_units
+auto_units=(
+  'h\:auto'
+  'H\:auto'
+)
+
+_arguments \
+  '(- *)'{-h,--help}'[print the help message]' \
+  '(-a)-a[sets the length of the time window for average calculation (default 300s)]:seconds' \
+  '(-m -i)-i[specifies the 100% mark of the incoming bandwidth graph(default 10240, ignored if 0)]:kBit/s' \
+  '(-i -o -m)-m[show multiple devices at a time; no traffic graphs]' \
+  '(-m -o)-o[specifies the 100% mark of the outgoing bandwidth graph(default 10240, ignored if 0)]:kBit/s' \
+  '(-t)-t[refresh interval of the display (default 500ms)]:milliseconds' \
+  "(-u)-u[type of unit used for the display of traffic numbers (default h)]::units:(($units2 $auto_units))" \
+  "(-U)-U[type of unit used for the display of total amount of data]::units:(($units $auto_units))" \
+
+# TODO: complete network devices as last argument


### PR DESCRIPTION
The only thing that is still missing is the completion of network devices as
remaining arguments.  Does anybody know some zsh way to do this or is it best
to parse the output of some command (which one is present in most cases?)?