### PR TITLE
Add support for local gradle wrapper, gradlew

### DIFF
--- a/src/_gradle
+++ b/src/_gradle
@@ -40,6 +40,10 @@
 #
 # ------------------------------------------------------------------------------
 
+# Wrapper Support 
+if [[ $service == "gradlew" && -x "./gradlew" ]] ; then
+    service="./$service"
+fi
 
 _gradle() {
   typeset -A opt_args


### PR DESCRIPTION
I'm running zsh 5.0.7 on Mac OS X, installed via brew.  I noticed that while `gradlew` is supported in the compdef, it won't actually execute one's wrapper (assuming current dir is not on path).