### PR TITLE
Update _ag completion

### DIFF
--- a/src/_ag
+++ b/src/_ag
@@ -53,14 +53,6 @@ _ag_add_version_opts() {
   local minor
   minor=$(_ag_version)
 
-  if [[ $minor -gt 15 ]];then
-    AG_OPTS+=(
-      '(--color-line-number)--color-line-number[Color codes for line numbers. Default is 1;33.]'
-      '(--color-match)--color-match[Color codes for result match numbers. Default is 30;43.]'
-      '(--color-path)--color-path[Color codes for path names. Default is 1;32.]'
-    )
-  fi
-
   if [[ $minor -gt 21 ]];then
     _ag_add_file_types
     AG_OPTS+=(
@@ -77,14 +69,14 @@ _ag_add_version_opts() {
 
   if [[ $minor -le 24 ]];then
     AG_OPTS+=(
-      '(--noheading --heading)'{--noheading,--heading}'[print file names above matching contents]'
       '(-s --case-sensitive)'{-s,--case-sensitive}'[match case sensitively]'
+      '(--noheading --heading)'{--noheading,--heading}'[print file names above matching contents]'
     )
   fi
   if [[ $minor -gt 24 ]];then
     AG_OPTS+=(
-      '(-H --noheading --heading)'{-H,--noheading,--heading}'[print file names above matching contents]'
       '(-s --case-sensitive)'{-s,--case-sensitive}'[Match case sensitively. Default on.]'
+      '(-H --noheading --heading)'{-H,--noheading,--heading}'[print file names above matching contents]'
       '(--vimgrep)--vimgrep[output results like vim''s, :vimgrep /pattern/g would (report every match on the line)]'
     )
   fi
@@ -135,37 +127,40 @@ _ag() {
       '(- 1 *)--man[print the manual page]'
       '(- 1 *)--version[display version and copyright information]'
       '(--ackmate)--ackmate[output results in a format parseable by AckMate]'
+      '(-A --after)'{-A,--after}'[Print NUM lines before match. Default is 2]:LINES'
+      '(-t --all-text)'{-t,--all-text}"[search all text files, not including hidden]"
+      '(-a --all-types)'{-a,--all-types}"[Search all files. This doesn't include hidden files, and also doesn't respect any ignore files.]"
+      '(-B --before)'{-B,--before}'[Print NUM lines after match. Defaults is 2]:LINES'
+      '(-C --context)'{-C,--context}'[Print NUM lines before and after matches. Default is 2.]:LINES'
+      '(--color-line-number)--color-line-number[Color codes for line numbers. Default is 1;33.]'
+      '(--color-match)--color-match[Color codes for result match numbers. Default is 30;43.]'
+      '(--color-path)--color-path[Color codes for path names. Default is 1;32.]'
       '(--column)--column[print column numbers in results]'
+      '(-D --debug)'{-D,--debug}'[enable debug logging]'
+      '(-G --file-search-regex)'{-G,--file-search-regex}'[only search file names matching PATTERN]:PATTERN'
+      '(-l --files-with-matches)'{-l,--files-with-matches}'[only print filenames containing matches, not matching lines]'
+      '(-L --files-without-matches)'{-L,--files-without-matches}"[only print filenames that don't contain matches]"
+      '(-f --follow)'{-f,--follow}'[follow symlinks]'
+      '(-g)-g[print filenames that match PATTERN]:PATTERN'
       '(--hidden)--hidden[search hidden files, still obeys ignore files.]'
       '(--ignore)--ignore[Ignore files/directories matching this pattern. Literal file and directory names are also allowed.]'
+      '(-i --ignore-case)'{-i,--ignore-case}'[match case insensitively]:PATTERN'
       '(--ignore-dir)--ignore-dir[alias for --ignore for compatability with ack]'
+      '(-v --invert-match)'{-v,--invert-match}'[invert match]'
+      '(-Q --literal)'{-Q,--literal}'[Do not parse PATTERN as a regular expression. Try to match it literally.]'
+      '(-m --max-count)'{-m,--max-count}'[Skip the rest of a file after NUM matches. Default is 10,000.]:NUM'
       '(--nobreak --break)'{--nobreak,--break}'[Print a newline between matches in different files. Default on.]'
       '(--nocolor --color)'{--nocolor,--color}'[Print color codes in results. Default on.]'
       '(--nogroup --group)'{--nogroup,--group}'[same as --\[no\]break --\[no\]heading]'
       '(--pager --nopager)'{--pager,--nopager}'[Display results with PAGER. Disabled by default.]'
       '(--passthrough)--passthrough[when searching a stream, print all lines even if they don''t match]'
+      '(-p --path-to-agignore)'{-p,--path-to-agignore}'[provide a path to a specific .agignore file]:STRING'
       '(--print-long-lines)--print-long-lines[Print matches on very long lines (> 2k characters by default)]'
       '(--search-binary)--search-binary[search binary files for matches]'
-      '(--stats)--stats[print stats (files scanned, time taken, etc)]'
-      '(-A --after)'{-A,--after}'[Print NUM lines before match. Default is 2]:LINES'
-      '(-B --before)'{-B,--before}'[Print NUM lines after match. Defaults is 2]:LINES'
-      '(-C --context)'{-C,--context}'[Print NUM lines before and after matches. Default is 2.]:LINES'
-      '(-D --debug)'{-D,--debug}'[enable debug logging]'
-      '(-G --file-search-regex)'{-G,--file-search-regex}'[only search file names matching PATTERN]:PATTERN'
-      '(-L --files-without-matches)'{-L,--files-without-matches}"[only print filenames that don't contain matches]"
-      '(-Q --literal)'{-Q,--literal}'[Do not parse PATTERN as a regular expression. Try to match it literally.]'
-      '(-S --smart-case)'{-S,--smart-case}'[match case sensitively if PATTERN contains any uppercase letters, else match case insensitively]'
       '(-U --skip-vcs-ignores)'{-U,--skip-vcs-ignores}'[ignore VCS ignore files (.gitigore, .hgignore, svn:ignore), but still use .agignore]'
-      '(-a --all-types)'{-a,--all-types}"[Search all files. This doesn't include hidden files, and also doesn't respect any ignore files.]"
-      '(-f --follow)'{-f,--follow}'[follow symlinks]'
-      '(-g)-g[print filenames that match PATTERN]:PATTERN'
-      '(-i --ignore-case)'{-i,--ignore-case}'[match case insensitively]:PATTERN'
-      '(-l --files-with-matches)'{-l,--files-with-matches}'[only print filenames containing matches, not matching lines]'
-      '(-m --max-count)'{-m,--max-count}'[Skip the rest of a file after NUM matches. Default is 10,000.]:NUM'
-      '(-p --path-to-agignore)'{-p,--path-to-agignore}'[provide a path to a specific .agignore file]:STRING'
-      '(-t --all-text)'{-t,--all-text}"[search all text files, not including hidden]"
+      '(-S --smart-case)'{-S,--smart-case}'[match case sensitively if PATTERN contains any uppercase letters, else match case insensitively]'
+      '(--stats)--stats[print stats (files scanned, time taken, etc)]'
       '(-u --unrestricted)'{-u,--unrestricted}'[Search *all* files. This ignores .agignore, .gitignore, etc. It searches binary and hidden files as well.]'
-      '(-v --invert-match)'{-v,--invert-match}'[invert match]'
       '(-w --word-regexp)'{-w,--word-regexp}'[only match whole words]'
       '*: :_files'
       '1: :->patterns'

--- a/src/_ag
+++ b/src/_ag
@@ -15,70 +15,167 @@
 # -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # vim: ft=zsh sw=2 ts=2 et
 # ------------------------------------------------------------------------------
+_ag_version() {
+  local version cnt=0
+  for i in $(ag --version); do
+    if [[ $cnt -eq 2 ]]; then
+      version=$i
+      break
+    fi
+    ((cnt += 1))
+  done
+
+  version=( "${(@s/./)version}" )
+  printf "${version[2]}"
+}
+
+# Dynamically build the file type completion
+# Modifies the global $__AG_OPTS array
+_ag_add_file_types() {
+  local ttype exts
+  for i in $(ag --list-file-types); do
+    if [[ "$i" =~ '--' ]]; then
+      if [[ "${ttype}x" != "x" ]]; then
+        __AG_OPTS+="(${ttype})${ttype}[${exts%% }]"
+      fi
+      ttype=$i
+      exts=
+    else
+      exts+="$i "
+    fi
+  done
+  __AG_OPTS+="(${ttype})${ttype}[${exts%% }]"
+}
+
+# Add version appropriate options above base
+# Modifies the global $__AG_OPTS array
+_ag_add_version_opts() {
+  local minor
+  minor=$(_ag_version)
+
+  if [[ $minor -gt 15 ]];then
+    __AG_OPTS+=(
+      '(--color-line-number)--color-line-number[Color codes for line numbers. Default is 1;33.]'
+      '(--color-match)--color-match[Color codes for result match numbers. Default is 30;43.]'
+      '(--color-path)--color-path[Color codes for path names. Default is 1;32.]'
+    )
+  fi
+
+  if [[ $minor -gt 21 ]];then
+    _ag_add_file_types
+    __AG_OPTS+=(
+      '(--list-file-types)--list-file-types[list supported filetypes to search]'
+      '(--silent)--silent[suppress all log messages, including errors]'
+    )
+  fi
+
+  if [[ $minor -gt 22 ]];then
+    __AG_OPTS+=(
+      '(-z --search-zip)'{-z,--search-zip}'[search contents of compressed files]'
+    )
+  fi
+
+  if [[ $minor -le 24 ]];then
+    __AG_OPTS+=(
+      '(--noheading --heading)'{--noheading,--heading}'[print file names above matching contents]'
+      '(-s --case-sensitive)'{-s,--case-sensitive}'[match case sensitively]'
+    )
+  fi
+  if [[ $minor -gt 24 ]];then
+    __AG_OPTS+=(
+      '(-H --noheading --heading)'{-H,--noheading,--heading}'[print file names above matching contents]'
+      '(-s --case-sensitive)'{-s,--case-sensitive}'[Match case sensitively. Default on.]'
+      '(--vimgrep)--vimgrep[output results like vim''s, :vimgrep /pattern/g would (report every match on the line)]'
+    )
+  fi
+
+  if [[ $minor -gt 26 ]];then
+    __AG_OPTS+=(
+      '(-0 --null --print0)'{-0,--null,--print0}'[separate the filenames with \\0, rather than \\n]'
+    )
+  fi
+
+  if [[ $minor -le 27 ]];then
+    __AG_OPTS+=(
+      '(--depth)--depth[Search up to NUM directories deep. Default is 25.]:NUM'
+    )
+  fi
+  if [[ $minor -gt 27 ]];then
+    __AG_OPTS+=(
+      '(-c --count)'{-c,--count}'[only print the number of matches in each file]'
+      '(--depth)--depth[Search up to NUM directories deep, -1 for unlimited. Default is 25.]:NUM'
+      '(-F --fixed-strings)'{-F,--fixed-strings}'[alias for --literal for compatibility with grep]'
+    )
+  fi
+
+  if [[ $minor -le 28 ]];then
+    __AG_OPTS+=(
+      '(--no-numbers)--no-numbers[don´t show line numbers]'
+    )
+  fi
+  if [[ $minor -gt 28 ]];then
+    __AG_OPTS+=(
+      '(--nofilename --filename)'{--nofilename,--filename}'[Print file names. Default on, except when searching a single file.]'
+      '(--nonumbers --numbers)'{--nonumbers,--numbers}'[Print line numbers. Default is to omit line numbers when searching streams]'
+      '(-o --only-matching)'{-o,--only-matching}'[print only the matching part of the lines]'
+    )
+  fi
+}
 
 _ag() {
-
   local curcontext="$curcontext" state line cmds update_policy ret=1
 
   zstyle -s ":completion:${curcontext}:" cache-policy update_policy
   [[ -z "$update_policy" ]] && zstyle ":completion:${curcontext}:" cache-policy _ag_types_caching_policy
 
-  if ( [[ ${+_ag_types} -eq 0 ]] || _cache_invalid "ag_types" ) && ! _retrieve_cache "ag_types"; then
-    _ag_types=( ${(f)"$(ag --list-file-types | awk ' /--/ { VAR=$1; gsub(/--/, "", VAR); \
-      getline; gsub(/^ */, ""); printf "%s %s\n", VAR, $0 } ')"} )
-    [[ $#_ag_types -gt 0 ]] && _store_cache 'ag_types' _ag_types
+  if ( [[ ${+__AG_OPTS} -eq 0 ]] || _cache_invalid "AG_OPTS" ) && ! _retrieve_cache "AG_OPTS"; then
+    # Base opts starts at ag version 0.14
+    __AG_OPTS=(
+      '(- 1 *)--help[print a short help statement]'
+      '(- 1 *)--man[print the manual page]'
+      '(- 1 *)--version[display version and copyright information]'
+      '(--ackmate)--ackmate[output results in a format parseable by AckMate]'
+      '(--column)--column[print column numbers in results]'
+      '(--hidden)--hidden[search hidden files, still obeys ignore files.]'
+      '(--ignore)--ignore[Ignore files/directories matching this pattern. Literal file and directory names are also allowed.]'
+      '(--ignore-dir)--ignore-dir[alias for --ignore for compatability with ack]'
+      '(--nobreak --break)'{--nobreak,--break}'[Print a newline between matches in different files. Default on.]'
+      '(--nocolor --color)'{--nocolor,--color}'[Print color codes in results. Default on.]'
+      '(--nogroup --group)'{--nogroup,--group}'[same as --\[no\]break --\[no\]heading]'
+      '(--pager --nopager)'{--pager,--nopager}'[Display results with PAGER. Disabled by default.]'
+      '(--passthrough)--passthrough[when searching a stream, print all lines even if they don''t match]'
+      '(--print-long-lines)--print-long-lines[Print matches on very long lines (> 2k characters by default)]'
+      '(--search-binary)--search-binary[search binary files for matches]'
+      '(--stats)--stats[print stats (files scanned, time taken, etc)]'
+      '(-A --after)'{-A,--after}'[Print NUM lines before match. Default is 2]:LINES'
+      '(-B --before)'{-B,--before}'[Print NUM lines after match. Defaults is 2]:LINES'
+      '(-C --context)'{-C,--context}'[Print NUM lines before and after matches. Default is 2.]:LINES'
+      '(-D --debug)'{-D,--debug}'[enable debug logging]'
+      '(-G --file-search-regex)'{-G,--file-search-regex}'[only search file names matching PATTERN]:PATTERN'
+      '(-L --files-without-matches)'{-L,--files-without-matches}"[only print filenames that don't contain matches]"
+      '(-Q --literal)'{-Q,--literal}'[Do not parse PATTERN as a regular expression. Try to match it literally.]'
+      '(-S --smart-case)'{-S,--smart-case}'[match case sensitively if PATTERN contains any uppercase letters, else match case insensitively]'
+      '(-U --skip-vcs-ignores)'{-U,--skip-vcs-ignores}'[ignore VCS ignore files (.gitigore, .hgignore, svn:ignore), but still use .agignore]'
+      '(-a --all-types)'{-a,--all-types}"[Search all files. This doesn't include hidden files, and also doesn't respect any ignore files.]"
+      '(-f --follow)'{-f,--follow}'[follow symlinks]'
+      '(-g)-g[print filenames that match PATTERN]:PATTERN'
+      '(-i --ignore-case)'{-i,--ignore-case}'[match case insensitively]:PATTERN'
+      '(-l --files-with-matches)'{-l,--files-with-matches}'[only print filenames containing matches, not matching lines]'
+      '(-m --max-count)'{-m,--max-count}'[Skip the rest of a file after NUM matches. Default is 10,000.]:NUM'
+      '(-p --path-to-agignore)'{-p,--path-to-agignore}'[provide a path to a specific .agignore file]:STRING'
+      '(-t --all-text)'{-t,--all-text}"[search all text files, not including hidden]"
+      '(-u --unrestricted)'{-u,--unrestricted}'[Search *all* files. This ignores .agignore, .gitignore, etc. It searches binary and hidden files as well.]'
+      '(-v --invert-match)'{-v,--invert-match}'[invert match]'
+      '(-w --word-regexp)'{-w,--word-regexp}'[only match whole words]'
+      '*: :_files'
+      '1: :->patterns'
+    )
+    _ag_add_version_opts
+    [[ $#__AG_OPTS -gt 0 ]] && _store_cache 'AG_OPTS' __AG_OPTS
   fi
 
-  _arguments -C \
-    '(- 1 *)--version[display version and copyright information]' \
-    '(- 1 *)--help[print a short help statement]' \
-    '(- 1 *)--man[print the manual page]' \
-    '(--ackmate)--ackmate[Output results in a format parseable by AckMate.]' \
-    '(-a --all-types)'{-a,--all-types}"[Search all files. This doesn't include hidden files, and also doesn't respect any ignore files.]" \
-    '(-A --after)'{-A,--after}'[Print lines before match. Defaults to 2.]:LINES' \
-    '(-B --before)'{-B,--before}'[Print lines after match. Defaults to 2.]:LINES' \
-    '(--nobreak --break)'{--nobreak,--break}'[Print a newline between matches in different files. Enabled by default.]' \
-    '(--nocolor --color)'{--nocolor,--color}'[Print color codes in results. Enabled by default.]' \
-    '(--color-line-number)--color-line-number[Color codes for line numbers. Defaults to 1;33.]' \
-    '(--color-match)--color-match[Color codes for result match numbers. Defaults to 30;43.]' \
-    '(--color-path)--color-path[Color codes for path names. Defaults to 1;32.]' \
-    '(--column)--column[Print column numbers in results.]' \
-    '(-C --context)'{-C,--context}'[Print lines before and after matches. Defaults to 2.]:LINES' \
-    '(-D --debug)'{-D,--debug}'[Ridiculous debugging. Probably not useful.]' \
-    '(--depth)--depth[Search up to NUM directories deep. Default is 25.]:NUM' \
-    '(-f --follow)'{-f,--follow}'[Follow symlinks.]' \
-    '(--nogroup --group)'{--nogroup,--group}'[Same as --\[no\]break --\[no\]heading]' \
-    '(-g)-g[Print filenames that match PATTERN]:PATTERN' \
-    '(-G --file-search-regex)'{-G,--file-search-regex}'[Only search file names matching PATTERN]:PATTERN' \
-    '(--noheading --heading)'{--noheading,--heading}'[\[no\]heading]' \
-    '(--hidden)--hidden[Search hidden files. This option obeys ignore files.]' \
-    '(-i --ignore-case)'{-i,--ignore-case}'[Match case insensitively]:PATTERN' \
-    '(--ignore)--ignore[Ignore files/directories matching this pattern. Literal file and directory names are also allowed.]' \
-    '(--ignore-dir)--ignore-dir[Alias for --ignore for compatability with ack.]' \
-    '(-l --files-with-matches)'{-l,--files-with-matches}'[Only print filenames containing matches, not matching lines.]' \
-    '(-L --files-without-matches)'{-L,--files-without-matches}"[Only print filenames that don't contain matches.]" \
-    '(--list-file-types)--list-file-types[List supported filetypes to search.]' \
-    '(-m --max-count)'{-m,--max-count}'[Skip the rest of a file after NUM matches. Default is 10,000.]:NUM' \
-    "(--no-numbers)--no-numbers[Don't show line numbers.]" \
-    '(-p --path-to-agignore)'{-p,--path-to-agignore}'[Provide a path to a specific .agignore file]:STRING' \
-    '(--pager --nopager)'{--pager,--nopager}'[Display results with PAGER. Disabled by default.]' \
-    '(--print-long-lines)--print-long-lines[Print matches on very long lines (> 2k characters by default)]' \
-    '(-Q --literal)'{-Q,--literal}'[Do not parse PATTERN as a regular expression. Try to match it literally.]' \
-    '(-s --case-sensitive)'{-s,--case-sensitive}'[Match case sensitively. Enabled by default.]' \
-    '(-S --smart-case)'{-S,--smart-case}'[Match case sensitively if there are any uppercase letters in PATTERN, or case insensitively otherwise.]' \
-    '(--search-binary)--search-binary[Search binary files for matches.]' \
-    '(--silent)--silent[Suppress all log messages, including errors.]' \
-    '(--stats)--stats[Print stats (files scanned, time taken, etc)]' \
-    '(-t --all-text)'{-t,--all-text}"[Search all text files. This doesn't include hidden files.]" \
-    '(-u --unrestricted)'{-u,--unrestricted}'[Search *all* files. This ignores .agignore, .gitignore, etc. It searches binary and hidden files as well.]' \
-    '(-U --skip-vcs-ignores)'{-U,--skip-vcs-ignores}'[Ignore VCS ignore files (.gitigore, .hgignore, svn:ignore), but still use .agignore.]' \
-    '(-v --invert-match)'{-v,--invert-match}'[invert match]' \
-    '(-w --word-regexp)'{-w,--word-regexp}'[Only match whole words.]' \
-    '(-z --search-zip)'{-z,--search-zip}'[Search contents of compressed file.]' \
-    {'--','--no'}${_ag_types/ ##/\[}']' \
-    '1: :->patterns' \
-    '*: :_files' \
-    && ret=0
+  _arguments -C ${__AG_OPTS} && ret=0
+  unset __AG_OPTS
 
   case $state in
     patterns)
@@ -90,7 +187,6 @@ _ag() {
 }
 
 _ag_types_caching_policy() {
-
   # Rebuild if .agignore more recent than cache.
   [[ -f $HOME/.agignore && $$HOME/.agignore -nt "$1" ]] && return 0
 

--- a/src/_ag
+++ b/src/_ag
@@ -30,13 +30,13 @@ _ag_version() {
 }
 
 # Dynamically build the file type completion
-# Modifies the global $__AG_OPTS array
+# Modifies the global $AG_OPTS array
 _ag_add_file_types() {
   local ttype exts
   for i in $(ag --list-file-types); do
     if [[ "$i" =~ '--' ]]; then
       if [[ "${ttype}x" != "x" ]]; then
-        __AG_OPTS+="(${ttype})${ttype}[${exts%% }]"
+        AG_OPTS+="(${ttype})${ttype}[${exts%% }]"
       fi
       ttype=$i
       exts=
@@ -44,17 +44,17 @@ _ag_add_file_types() {
       exts+="$i "
     fi
   done
-  __AG_OPTS+="(${ttype})${ttype}[${exts%% }]"
+  AG_OPTS+="(${ttype})${ttype}[${exts%% }]"
 }
 
 # Add version appropriate options above base
-# Modifies the global $__AG_OPTS array
+# Modifies the global $AG_OPTS array
 _ag_add_version_opts() {
   local minor
   minor=$(_ag_version)
 
   if [[ $minor -gt 15 ]];then
-    __AG_OPTS+=(
+    AG_OPTS+=(
       '(--color-line-number)--color-line-number[Color codes for line numbers. Default is 1;33.]'
       '(--color-match)--color-match[Color codes for result match numbers. Default is 30;43.]'
       '(--color-path)--color-path[Color codes for path names. Default is 1;32.]'
@@ -63,26 +63,26 @@ _ag_add_version_opts() {
 
   if [[ $minor -gt 21 ]];then
     _ag_add_file_types
-    __AG_OPTS+=(
+    AG_OPTS+=(
       '(--list-file-types)--list-file-types[list supported filetypes to search]'
       '(--silent)--silent[suppress all log messages, including errors]'
     )
   fi
 
   if [[ $minor -gt 22 ]];then
-    __AG_OPTS+=(
+    AG_OPTS+=(
       '(-z --search-zip)'{-z,--search-zip}'[search contents of compressed files]'
     )
   fi
 
   if [[ $minor -le 24 ]];then
-    __AG_OPTS+=(
+    AG_OPTS+=(
       '(--noheading --heading)'{--noheading,--heading}'[print file names above matching contents]'
       '(-s --case-sensitive)'{-s,--case-sensitive}'[match case sensitively]'
     )
   fi
   if [[ $minor -gt 24 ]];then
-    __AG_OPTS+=(
+    AG_OPTS+=(
       '(-H --noheading --heading)'{-H,--noheading,--heading}'[print file names above matching contents]'
       '(-s --case-sensitive)'{-s,--case-sensitive}'[Match case sensitively. Default on.]'
       '(--vimgrep)--vimgrep[output results like vim''s, :vimgrep /pattern/g would (report every match on the line)]'
@@ -90,18 +90,18 @@ _ag_add_version_opts() {
   fi
 
   if [[ $minor -gt 26 ]];then
-    __AG_OPTS+=(
+    AG_OPTS+=(
       '(-0 --null --print0)'{-0,--null,--print0}'[separate the filenames with \\0, rather than \\n]'
     )
   fi
 
   if [[ $minor -le 27 ]];then
-    __AG_OPTS+=(
+    AG_OPTS+=(
       '(--depth)--depth[Search up to NUM directories deep. Default is 25.]:NUM'
     )
   fi
   if [[ $minor -gt 27 ]];then
-    __AG_OPTS+=(
+    AG_OPTS+=(
       '(-c --count)'{-c,--count}'[only print the number of matches in each file]'
       '(--depth)--depth[Search up to NUM directories deep, -1 for unlimited. Default is 25.]:NUM'
       '(-F --fixed-strings)'{-F,--fixed-strings}'[alias for --literal for compatibility with grep]'
@@ -109,12 +109,12 @@ _ag_add_version_opts() {
   fi
 
   if [[ $minor -le 28 ]];then
-    __AG_OPTS+=(
+    AG_OPTS+=(
       '(--no-numbers)--no-numbers[don´t show line numbers]'
     )
   fi
   if [[ $minor -gt 28 ]];then
-    __AG_OPTS+=(
+    AG_OPTS+=(
       '(--nofilename --filename)'{--nofilename,--filename}'[Print file names. Default on, except when searching a single file.]'
       '(--nonumbers --numbers)'{--nonumbers,--numbers}'[Print line numbers. Default is to omit line numbers when searching streams]'
       '(-o --only-matching)'{-o,--only-matching}'[print only the matching part of the lines]'
@@ -128,9 +128,9 @@ _ag() {
   zstyle -s ":completion:${curcontext}:" cache-policy update_policy
   [[ -z "$update_policy" ]] && zstyle ":completion:${curcontext}:" cache-policy _ag_types_caching_policy
 
-  if ( [[ ${+__AG_OPTS} -eq 0 ]] || _cache_invalid "AG_OPTS" ) && ! _retrieve_cache "AG_OPTS"; then
+  if ( [[ ${+AG_OPTS} -eq 0 ]] || _cache_invalid "_AG_OPTS" ) && ! _retrieve_cache "_AG_OPTS"; then
     # Base opts starts at ag version 0.14
-    __AG_OPTS=(
+    AG_OPTS=(
       '(- 1 *)--help[print a short help statement]'
       '(- 1 *)--man[print the manual page]'
       '(- 1 *)--version[display version and copyright information]'
@@ -171,11 +171,11 @@ _ag() {
       '1: :->patterns'
     )
     _ag_add_version_opts
-    [[ $#__AG_OPTS -gt 0 ]] && _store_cache 'AG_OPTS' __AG_OPTS
+    [[ $#AG_OPTS -gt 0 ]] && _store_cache '_AG_OPTS' AG_OPTS
   fi
 
-  _arguments -C ${__AG_OPTS} && ret=0
-  unset __AG_OPTS
+  _arguments -C ${AG_OPTS} && ret=0
+  unset AG_OPTS
 
   case $state in
     patterns)

--- a/src/_ag
+++ b/src/_ag
@@ -174,7 +174,7 @@ _ag() {
     [[ $#AG_OPTS -gt 0 ]] && _store_cache '_AG_OPTS' AG_OPTS
   fi
 
-  _arguments -C ${AG_OPTS} && ret=0
+  _arguments -C -s ${AG_OPTS} && ret=0
   unset AG_OPTS
 
   case $state in


### PR DESCRIPTION
* Simplified parsing of filetypes, no more awk-fu!
* Added version based checks to complete only existing features
*   Due to ag's unstable nature, this will help completing right things based on version.
* Added missing opt --passthrough
* Lowercased all strings not 2 sentences
* Instead of just caching types, I'm caching the whole opts since the work for init setup increased.

Still outstanding question:
Not sure what to do with uppercased lines with multiple sentences.