### PR TITLE
improve fix for issue-338

### DIFF
--- a/src/_adb
+++ b/src/_adb
@@ -253,7 +253,7 @@ _adb_product_names() {
 
 (( $+functions[_adb_serial_numbers] )) ||
 _adb_serial_numbers() {
-  local serial_numbers; serial_numbers=(${${(M)${(f)"$(_call_program devices $service devices)"/:/\\:}:#*device}%%[[:space:]]*}":connected device")
+  local serial_numbers; serial_numbers=(${${(M)${(f)"$(_call_program devices $service devices)"//:/\\:}:#*device}%%[[:space:]]*}":connected device")
   [[ -n "$ANDROID_SERIAL" ]] && serial_numbers+=("$ANDROID_SERIAL:default value set in ANDROID_SERIAL environment variable")
   _describe -t serial-numbers 'serial number' serial_numbers "$@" && ret=0
 }


### PR DESCRIPTION
- replace all occurence of : to \:
- consider the case there are multiple tcp adb connections
        $ adb devices
        List of devices attached
        192.168.0.139:5555      device
        192.168.0.225:5555      device
  all of colon has to be replaced, otherwise, we get this wrong result:
        $ adb -s 192.168.0.
        192.168.0.139:5555  -- connected device
        192.168.0.225       -- 5555:connected device