### PR TITLE
Use BSD and Gnu compatible option for tail

### DIFF
--- a/src/_docker-machine
+++ b/src/_docker-machine
@@ -18,7 +18,7 @@
 # helper function for completing available machines
 __machines() {
   declare -a machines_cmd
-  machines_cmd=($(docker-machine ls|tail +2|awk '{print $1":"$3"("$4")"}'))
+  machines_cmd=($(docker-machine ls|tail -n +2|awk '{print $1":"$3"("$4")"}'))
   _describe 'machines' machines_cmd
 }
 


### PR DESCRIPTION
Use 'tail -n +2' instead of 'tail +2'. Semanctics are the
same but 'tail +2' is not accepted by Gnu tail.