### PR TITLE
Ignore comments in ansible hosts

### DIFF
--- a/src/_ansible
+++ b/src/_ansible
@@ -91,7 +91,7 @@ __host_list ()
   local -a mixed_host_list
   mixed_host_list=$(command \
     cat ${HOST_FILE} \
-    | awk 'NF && $1 !~ /[\[:=]/ { print $1 }' \
+    | awk 'NF && $1 !~ /^[:space:]*#|[\[:=]/ { print $1 }' \
     | sort | uniq)
 
   # compute set difference h1 - h2


### PR DESCRIPTION
Ansible hosts file may contain comments starting with # character. These lines should be ignored when building autocompletion dictionary.