### PR TITLE
not using old Bourne shell, so no need to use backticks

### DIFF
--- a/src/_artisan
+++ b/src/_artisan
@@ -45,7 +45,7 @@ _artisan_get_command_list () {
 
 _artisan () {
     if [ -f artisan ]; then
-        compadd `_artisan_get_command_list`
+        compadd $(_artisan_get_command_list)
     fi
 }
 

--- a/src/_composer
+++ b/src/_composer
@@ -62,10 +62,10 @@ _composer () {
   if [ -f composer.json ]; then
     case $state in
       command)
-        compadd `_composer_get_command_list`
+        compadd $(_composer_get_command_list)
         ;;
       *)
-        compadd `_composer_get_required_list`
+        compadd $(_composer_get_required_list)
         ;;
     esac
   else

--- a/src/_console
+++ b/src/_console
@@ -45,7 +45,7 @@ _console_get_command_list () {
 
 _console () {
     if [ -f console ]; then
-        compadd `_console_get_command_list`
+        compadd $(_console_get_command_list)
     fi
 }
 

--- a/src/_fab
+++ b/src/_fab
@@ -20,7 +20,7 @@ local curcontext=$curcontext state line
 declare -A opt_args
 
 declare target_list
-target_list=(`fab --shortlist 2>/dev/null`)
+target_list=($(fab --shortlist 2>/dev/null))
 
 _targets() {
     _describe -t commands "fabric targets" target_list

--- a/src/_lunchy
+++ b/src/_lunchy
@@ -37,10 +37,10 @@ case $state in
       (install)
         ;;
       (restart|stop)
-        _values 'items' `lunchy status | awk '{print $3}' ` 2>/dev/null && ret=0
+        _values 'items' $(lunchy status | awk '{print $3}') 2>/dev/null && ret=0
         ;;
       *)
-        _values 'items' `lunchy ls` 2>/dev/null && ret=0
+        _values 'items' $(lunchy ls) 2>/dev/null && ret=0
         ;;
     esac
     ;;

--- a/src/_nvm
+++ b/src/_nvm
@@ -40,7 +40,7 @@ __nvm_aliases(){
   local aliases
   aliases=""
   if [ -d $NVM_DIR/alias ]; then
-    aliases="`cd $NVM_DIR/alias && ls`"
+    aliases="$(cd $NVM_DIR/alias && ls)"
   fi
   echo "${aliases}"
 }

--- a/src/_thor
+++ b/src/_thor
@@ -17,7 +17,7 @@
 
 
 # FIXME This should be rewritten using up-to-date ZSH completion API.
-compadd `thor list | grep thor | cut -d " " -f 2`
+compadd $(thor list | grep thor | cut -d " " -f 2)
 
 # Local Variables:
 # mode: Shell-Script

--- a/zsh-completions.plugin.zsh
+++ b/zsh-completions.plugin.zsh
@@ -1,1 +1,1 @@
-fpath+="`dirname $0`/src"
+fpath+="$(dirname $0)/src"


### PR DESCRIPTION
backticks are obsolete. They make reading code unnecessarily difficult. They are only requires by old (true) Bourne shells, like Heirloom, which there is no reason to support. 