### PR TITLE
_brew: alfred is no longer a valid cask command

### DIFF
--- a/src/_brew
+++ b/src/_brew
@@ -41,7 +41,6 @@ _brew_outdated_formulae() {
 _brew_cask() {
   local -a _1st_arguments
   _1st_arguments=(
-    "alfred:displays note about new built-in alfred support"
     "audit:verifies installability of Casks"
     "cat:dump raw source of the given Cask to the standard output"
     "cleanup:cleans up cached downloads and tracker symlinks"


### PR DESCRIPTION
Support for it was removed a good while ago.