### PR TITLE
symfony console completion should also work with php app/console

### DIFF
--- a/src/_console
+++ b/src/_console
@@ -39,6 +39,10 @@
 # ------------------------------------------------------------------------------
 
 
+_app_console_get_command_list () {
+    php app/console --no-ansi | sed "1,/Available commands/d" | awk '/ [a-z]+/ { print $1 }'
+}
+
 _console_get_command_list () {
     php console --no-ansi | sed "1,/Available commands/d" | awk '/ [a-z]+/ { print $1 }'
 }
@@ -46,8 +50,11 @@ _console_get_command_list () {
 _console () {
     if [ -f console ]; then
         compadd `_console_get_command_list`
+    elif [ -f app/console ]; then
+        compadd `_app_console_get_command_list`
     fi
 }
 
+compdef _console php app/console
 compdef _console php console
 compdef _console console


### PR DESCRIPTION
Symfony console completation should also work with `php app/console`. Right now it's only work with `php console` or `console`