### PR TITLE
Add Homebrew Cask completions

### DIFF
--- a/src/_brew_cask
+++ b/src/_brew_cask
@@ -1,0 +1,83 @@
+#compdef brew-cask
+#autoload
+
+# Autocompletion for homebrew-cask (https://github.com/caskroom/homebrew-cask/).
+#
+# Originally sourced from the oh-my-zsh
+# https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/brew-cask/brew-cask.plugin.zsh
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2009-2016 Robby Russell and contributors
+# See the full list at https://github.com/robbyrussell/oh-my-zsh/contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+_brew_cask()
+{
+  local curcontext="$curcontext" state state_descr line
+  typeset -A opt_args
+
+  _arguments -C \
+    ':subcmd:->subcmd' \
+    '*::options:->options'
+
+  case $state in
+  (subcmd)
+    local -a subcommands
+    subcommands=(
+      'audit:verifies installability of Casks'
+      'cat:dump raw source of the given Cask to the standard output'
+      'cleanup:cleans up cached downloads and tracker symlinks'
+      'create:creates the given Cask and opens it in an editor'
+      'doctor:checks for configuration issues'
+      'edit:edits the given Cask'
+      'fetch:downloads remote application files to local cache'
+      'home:opens the homepage of the given Cask'
+      'info:displays information about the given Cask'
+      'install:installs the given Cask'
+      'list:with no args, lists installed Casks; given installed Casks, lists staged files'
+      'search:searches all known Casks'
+      'style:checks Cask style using RuboCop'
+      'uninstall:uninstalls the given Cask'
+      "update:a synonym for 'brew update'"
+      'zap:zaps all files associated with the given Cask'
+    )
+    _describe -t commands "brew cask subcommand" subcommands ;;
+  (options)
+    local -a casks installed_casks
+    local expl
+    case "$line[1]" in
+      list|uninstall)
+        __brew_installed_casks
+        _wanted installed_casks expl 'installed casks' compadd -a installed_casks ;;
+      audit|cat|edit|fetch|home|info|install|zap)
+        __brew_all_casks
+        _wanted casks expl 'all casks' compadd -a casks ;;
+    esac ;;
+  esac
+}
+
+__brew_all_casks() {
+  casks=(`brew cask search`)
+}
+
+__brew_installed_casks() {
+  installed_casks=(`brew cask list|sed 's/(!)//'`)
+}


### PR DESCRIPTION
This completion was originally sourced from the oh-my-zsh brew cask plugin.
(https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/brew-cask/brew-cask.plugin.zsh)
The original plugin suffers from the following issues (IMO):
1. it is part of oh-my-zsh which some have chosen not to use
2. it acts as a script overriding the existing brew completion rather than as a
standard autoloadable file, this means it must be manually installed rather than
automatically installed as part of compinit.

The changes from the plugin are to fix item 2, as well as update the commands to
those current in homebrew cask. This change relies on a change pending in the
homebrew completion to allow it to call subcommand completions (see
https://github.com/joshka/brew/commit/6b010c5700095685bad6797038e83ef558df5104)
and hence should not be merged until that has been merged.

Ideally, this completion would be installed as part of the homebrew cask
installation, but there doesn't seem to be an easy way to do so as it is
homebrew cask is installed as a homebrew tap. It also doesn't really fit in the
homebrew main repo for similar reasons.

See related PRs:
https://github.com/robbyrussell/oh-my-zsh/pull/5191
https://github.com/Homebrew/brew/pull/407