### PR TITLE
Add completion script for git-journal

### DIFF
--- a/src/_git-journal
+++ b/src/_git-journal
@@ -1,0 +1,190 @@
+#compdef git-journal
+
+_git-journal() {
+	typeset -A opt_args
+	local ret=1
+
+	local context curcontext="$curcontext" state line
+    _arguments -s -S -C \
+"-p+[Sets a custom working path.]" \
+"--path+[Sets a custom working path.]" \
+"-n+[The number of tags until the parser stops when a single revision is given.]" \
+"--tags-count+[The number of tags until the parser stops when a single revision is given.]" \
+"-e+[A pattern to exclude git tags from the processing.]" \
+"-t+[Use a custom output template.]" \
+"--template+[Use a custom output template.]" \
+"-o+[The output file for the changelog.]" \
+"--output+[The output file for the changelog.]" \
+"-a[Do not stop parsing at the first tag when a single revision is given. Overwrites '-n/--tags-count'.]" \
+"--all[Do not stop parsing at the first tag when a single revision is given. Overwrites '-n/--tags-count'.]" \
+"-g[Generate a fresh output template from a commit range.]" \
+"--generate[Generate a fresh output template from a commit range.]" \
+"-s[Print only the shortlog (summary) form.]" \
+"--short[Print only the shortlog (summary) form.]" \
+"-u[Skip entries without any relation to a git TAG.]" \
+"--skip-unreleased[Skip entries without any relation to a git TAG.]" \
+"-h[Prints help information]" \
+"--help[Prints help information]" \
+"-V[Prints version information]" \
+"--version[Prints version information]" \
+"1:: :_git-journal_commands" \
+"*:: :->git-journal" \
+&& ret=0
+    case $state in
+    (git-journal)
+        curcontext="${curcontext%:*:*}:git-journal-command-$words[1]:"
+        case $line[1] in
+            (p)
+_arguments -s -S -C \
+"-h[Prints help information]" \
+"--help[Prints help information]" \
+"-V[Prints version information]" \
+"--version[Prints version information]" \
+"1:: :_git-journal_prepare_commands" \
+&& ret=0
+;;
+(prepare)
+_arguments -s -S -C \
+"-h[Prints help information]" \
+"--help[Prints help information]" \
+"-V[Prints version information]" \
+"--version[Prints version information]" \
+"1:: :_git-journal_prepare_commands" \
+&& ret=0
+;;
+(s)
+_arguments -s -S -C \
+"-h[Prints help information]" \
+"--help[Prints help information]" \
+"-V[Prints version information]" \
+"--version[Prints version information]" \
+&& ret=0
+;;
+(setup)
+_arguments -s -S -C \
+"-h[Prints help information]" \
+"--help[Prints help information]" \
+"-V[Prints version information]" \
+"--version[Prints version information]" \
+&& ret=0
+;;
+(v)
+_arguments -s -S -C \
+"-h[Prints help information]" \
+"--help[Prints help information]" \
+"-V[Prints version information]" \
+"--version[Prints version information]" \
+"1:: :_git-journal_verify_commands" \
+&& ret=0
+;;
+(verify)
+_arguments -s -S -C \
+"-h[Prints help information]" \
+"--help[Prints help information]" \
+"-V[Prints version information]" \
+"--version[Prints version information]" \
+"1:: :_git-journal_verify_commands" \
+&& ret=0
+;;
+(help)
+_arguments -s -S -C \
+"-h[Prints help information]" \
+"--help[Prints help information]" \
+"-V[Prints version information]" \
+"--version[Prints version information]" \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+}
+
+(( $+functions[_git-journal_commands] )) ||
+_git-journal_commands() {
+    local commands; commands=(
+        "prepare:Prepare a commit message before the user can edit it." \
+"p:Prepare a commit message before the user can edit it." \
+"setup:Creates all necessary git hooks and an initial configuration file. Shell completions for bash and fish will be available inside the current working directory." \
+"s:Creates all necessary git hooks and an initial configuration file. Shell completions for bash and fish will be available inside the current working directory." \
+"verify:Verify the specified commit message." \
+"v:Verify the specified commit message." \
+"help:Prints this message or the help of the given subcommand(s)" \
+"REVISION_RANGE:Specifies the revision range to be processed. If a single revision is specified, the output will stop at the first following git TAG." \
+    )
+    _describe -t commands 'git-journal commands' commands "$@"
+}
+(( $+functions[_git-journal_help_commands] )) ||
+_git-journal_help_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'git-journal help commands' commands "$@"
+}
+(( $+functions[_git-journal_p_commands] )) ||
+_git-journal_p_commands() {
+    local commands; commands=(
+        "MESSAGE:The path to the commit message which should be prepared." \
+"TYPE:The type of the commit. For example "message"." \
+    )
+    _describe -t commands 'git-journal p commands' commands "$@"
+}
+(( $+functions[_p_commands] )) ||
+_p_commands() {
+    local commands; commands=(
+        "MESSAGE:The path to the commit message which should be prepared." \
+"TYPE:The type of the commit. For example "message"." \
+    )
+    _describe -t commands 'p commands' commands "$@"
+}
+(( $+functions[_git-journal_prepare_commands] )) ||
+_git-journal_prepare_commands() {
+    local commands; commands=(
+        "MESSAGE:The path to the commit message which should be prepared." \
+"TYPE:The type of the commit. For example "message"." \
+    )
+    _describe -t commands 'git-journal prepare commands' commands "$@"
+}
+(( $+functions[_git-journal_s_commands] )) ||
+_git-journal_s_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'git-journal s commands' commands "$@"
+}
+(( $+functions[_s_commands] )) ||
+_s_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 's commands' commands "$@"
+}
+(( $+functions[_git-journal_setup_commands] )) ||
+_git-journal_setup_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'git-journal setup commands' commands "$@"
+}
+(( $+functions[_git-journal_v_commands] )) ||
+_git-journal_v_commands() {
+    local commands; commands=(
+        "MESSAGE:The path to the commit message which should be prepared." \
+    )
+    _describe -t commands 'git-journal v commands' commands "$@"
+}
+(( $+functions[_v_commands] )) ||
+_v_commands() {
+    local commands; commands=(
+        "MESSAGE:The path to the commit message which should be prepared." \
+    )
+    _describe -t commands 'v commands' commands "$@"
+}
+(( $+functions[_git-journal_verify_commands] )) ||
+_git-journal_verify_commands() {
+    local commands; commands=(
+        "MESSAGE:The path to the commit message which should be prepared." \
+    )
+    _describe -t commands 'git-journal verify commands' commands "$@"
+}
+
+_git-journal "$@"

--- a/src/_git-journal
+++ b/src/_git-journal
@@ -1,4 +1,39 @@
 #compdef git-journal
+# ------------------------------------------------------------------------------
+# Copyright (c) 2011 Github zsh-users - http://github.com/zsh-users
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+# 
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+# Completion script for git-journal:
+# https://github.com/saschagrunert/git-journal
+#
+# Authors
+# -------
+#
+# * Sascha Grunert <mail@saschagruenrt.de>
+# * Nico Wagner <nico@cryptopone.org>
+# ------------------------------------------------------------------------------
 
 _git-journal() {
 	typeset -A opt_args


### PR DESCRIPTION
add completion script for git-journal a git commit message and changelog generation framework. the completion file was autogenerated by calp-rs.