### PR TITLE
fix version logic for major version > 0

### DIFF
--- a/src/_ag
+++ b/src/_ag
@@ -40,13 +40,22 @@
 # -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # vim: ft=zsh sw=2 ts=2 et
 # ------------------------------------------------------------------------------
-_ag_version() {
+_ag_minor_version() {
   local version
   version=( $($words[1] --version) )
   version=${version[@]:2:1}
   version=( "${(@s/./)version}" )
   echo "${version[2]}"
 }
+
+_ag_major_version() {
+  local version
+  version=( $($words[1] --version) )
+  version=${version[@]:2:1}
+  version=( "${(@s/./)version}" )
+  echo "${version[1]}"
+}
+
 
 # Dynamically build the file type completion
 # Modifies the global $AG_OPTS array
@@ -69,9 +78,10 @@ _ag_add_file_types() {
 # Add version appropriate options above base
 # Modifies the global $AG_OPTS array
 _ag_add_version_opts() {
-  local minor=$(_ag_version)
+  local minor=$(_ag_minor_version)
+  local major=$(_ag_major_version)
 
-  if [[ $minor -gt 21 ]];then
+  if [[ $major -ge 1 || $minor -gt 21 ]];then
     _ag_add_file_types
     AG_OPTS+=(
       '(- 1 *)--list-file-types[list supported filetypes to search]'
@@ -79,19 +89,19 @@ _ag_add_version_opts() {
     )
   fi
 
-  if [[ $minor -gt 22 ]];then
+  if [[ $major -ge 1 || $minor -gt 22 ]];then
     AG_OPTS+=(
       '(-z --search-zip)'{-z,--search-zip}'[search contents of compressed files]'
     )
   fi
 
-  if [[ $minor -le 24 ]];then
+  if [[ $major -lt 1 && $minor -le 24 ]];then
     AG_OPTS+=(
       '(-s --case-sensitive)'{-s,--case-sensitive}'[match case sensitively]'
       '(--noheading --heading)'{--noheading,--heading}'[print file names above matching contents]'
     )
   fi
-  if [[ $minor -gt 24 ]];then
+  if [[ $major -ge 1 || $minor -gt 24 ]];then
     AG_OPTS+=(
       '(-s --case-sensitive)'{-s,--case-sensitive}'[Match case sensitively. Default on.]'
       '(-H --noheading --heading)'{-H,--noheading,--heading}'[print file names above matching contents]'
@@ -99,18 +109,18 @@ _ag_add_version_opts() {
     )
   fi
 
-  if [[ $minor -gt 26 ]];then
+  if [[ $major -ge 1 || $minor -gt 26 ]];then
     AG_OPTS+=(
       '(-0 --null --print0)'{-0,--null,--print0}'[separate the filenames with \\0, rather than \\n]'
     )
   fi
 
-  if [[ $minor -le 27 ]];then
+  if [[ $major -lt 1 && $minor -le 27 ]];then
     AG_OPTS+=(
       '--depth[Search up to NUM directories deep. Default is 25.]:number'
     )
   fi
-  if [[ $minor -gt 27 ]];then
+  if [[ $major -ge 1 || $minor -gt 27 ]];then
     AG_OPTS+=(
       '(-c --count)'{-c,--count}'[only print the number of matches in each file]'
       '--depth[Search up to NUM directories deep, -1 for unlimited. Default is 25.]:number'
@@ -118,12 +128,12 @@ _ag_add_version_opts() {
     )
   fi
 
-  if [[ $minor -le 28 ]];then
+  if [[ $major -lt 1 && $minor -le 28 ]];then
     AG_OPTS+=(
       '(--no-numbers)--no-numbers[don´t show line numbers]'
     )
   fi
-  if [[ $minor -gt 28 ]];then
+  if [[ $major -ge 1 || $minor -gt 28 ]];then
     AG_OPTS+=(
       '(--nofilename --filename)'{--nofilename,--filename}'[Print file names. Default on, except when searching a single file.]'
       '(--nonumbers --numbers)'{--nonumbers,--numbers}'[Print line numbers. Default is to omit line numbers when searching streams]'

--- a/src/_ag
+++ b/src/_ag
@@ -72,7 +72,7 @@ _ag_add_file_types() {
 _ag_add_version_opts() {
   local ag_version=$(_ag_version)
 
-  if [[ ag_version > 0.22 ]]; then
+  if [[ $ag_version > 0.22 ]]; then
     _ag_add_file_types
     AG_OPTS+=(
       '(- 1 *)--list-file-types[list supported filetypes to search]'
@@ -81,19 +81,19 @@ _ag_add_version_opts() {
   fi
     
 
-  if [[ ag_version > 0.22 ]]; then
+  if [[ $ag_version > 0.22 ]]; then
     AG_OPTS+=(
       '(-z --search-zip)'{-z,--search-zip}'[search contents of compressed files]'
     )
   fi
 
-  if [[ ag_version <= 0.24 ]]; then
+  if [[ $ag_version <= 0.24 ]]; then
     AG_OPTS+=(
       '(-s --case-sensitive)'{-s,--case-sensitive}'[match case sensitively]'
       '(--noheading --heading)'{--noheading,--heading}'[print file names above matching contents]'
     )
   fi
-  if [[ ag_version > 0.24 ]]; then
+  if [[ $ag_version > 0.24 ]]; then
     AG_OPTS+=(
       '(-s --case-sensitive)'{-s,--case-sensitive}'[Match case sensitively. Default on.]'
       '(-H --noheading --heading)'{-H,--noheading,--heading}'[print file names above matching contents]'
@@ -101,18 +101,18 @@ _ag_add_version_opts() {
     )
   fi
 
-  if [[ ag_version > 0.26 ]]; then
+  if [[ $ag_version > 0.26 ]]; then
     AG_OPTS+=(
       '(-0 --null --print0)'{-0,--null,--print0}'[separate the filenames with \\0, rather than \\n]'
     )
   fi
 
-  if [[ ag_version <= 0.27 ]]; then
+  if [[ $ag_version <= 0.27 ]]; then
     AG_OPTS+=(
       '--depth[Search up to NUM directories deep. Default is 25.]:number'
     )
   fi
-  if [[ ag_version > 0.27 ]]; then
+  if [[ $ag_version > 0.27 ]]; then
     AG_OPTS+=(
       '(-c --count)'{-c,--count}'[only print the number of matches in each file]'
       '--depth[Search up to NUM directories deep, -1 for unlimited. Default is 25.]:number'
@@ -120,12 +120,12 @@ _ag_add_version_opts() {
     )
   fi
 
-  if [[ ag_version <= 0.28 ]]; then
+  if [[ $ag_version <= 0.28 ]]; then
     AG_OPTS+=(
       '(--no-numbers)--no-numbers[don´t show line numbers]'
     )
   fi
-  if [[ ag_version > 0.28 ]]; then
+  if [[ $ag_version > 0.28 ]]; then
     AG_OPTS+=(
       '(--nofilename --filename)'{--nofilename,--filename}'[Print file names. Default on, except when searching a single file.]'
       '(--nonumbers --numbers)'{--nonumbers,--numbers}'[Print line numbers. Default is to omit line numbers when searching streams]'

--- a/src/_ag
+++ b/src/_ag
@@ -72,7 +72,7 @@ _ag_add_file_types() {
 _ag_add_version_opts() {
   local ag_version=$(_ag_version)
 
-  if [[ $ag_version > 0.22 ]]; then
+  if [[ $ag_version > 0.21 ]]; then
     _ag_add_file_types
     AG_OPTS+=(
       '(- 1 *)--list-file-types[list supported filetypes to search]'

--- a/src/_ag
+++ b/src/_ag
@@ -40,20 +40,12 @@
 # -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # vim: ft=zsh sw=2 ts=2 et
 # ------------------------------------------------------------------------------
-_ag_minor_version() {
-  local version
-  version=( $($words[1] --version) )
-  version=${version[@]:2:1}
-  version=( "${(@s/./)version}" )
-  echo "${version[2]}"
-}
 
-_ag_major_version() {
+_ag_version() {
   local version
   version=( $($words[1] --version) )
-  version=${version[@]:2:1}
-  version=( "${(@s/./)version}" )
-  echo "${version[1]}"
+  version=${${(z)${version[1]}}[2]}
+  echo $version
 }
 
 
@@ -78,30 +70,30 @@ _ag_add_file_types() {
 # Add version appropriate options above base
 # Modifies the global $AG_OPTS array
 _ag_add_version_opts() {
-  local minor=$(_ag_minor_version)
-  local major=$(_ag_major_version)
+  local ag_version=$(_ag_version)
 
-  if [[ $major -ge 1 || $minor -gt 21 ]];then
+  if [[ ag_version > 0.22 ]]; then
     _ag_add_file_types
     AG_OPTS+=(
       '(- 1 *)--list-file-types[list supported filetypes to search]'
       '--silent[suppress all log messages, including errors]'
     )
   fi
+    
 
-  if [[ $major -ge 1 || $minor -gt 22 ]];then
+  if [[ ag_version > 0.22 ]]; then
     AG_OPTS+=(
       '(-z --search-zip)'{-z,--search-zip}'[search contents of compressed files]'
     )
   fi
 
-  if [[ $major -lt 1 && $minor -le 24 ]];then
+  if [[ ag_version <= 0.24 ]]; then
     AG_OPTS+=(
       '(-s --case-sensitive)'{-s,--case-sensitive}'[match case sensitively]'
       '(--noheading --heading)'{--noheading,--heading}'[print file names above matching contents]'
     )
   fi
-  if [[ $major -ge 1 || $minor -gt 24 ]];then
+  if [[ ag_version > 0.24 ]]; then
     AG_OPTS+=(
       '(-s --case-sensitive)'{-s,--case-sensitive}'[Match case sensitively. Default on.]'
       '(-H --noheading --heading)'{-H,--noheading,--heading}'[print file names above matching contents]'
@@ -109,18 +101,18 @@ _ag_add_version_opts() {
     )
   fi
 
-  if [[ $major -ge 1 || $minor -gt 26 ]];then
+  if [[ ag_version > 0.26 ]]; then
     AG_OPTS+=(
       '(-0 --null --print0)'{-0,--null,--print0}'[separate the filenames with \\0, rather than \\n]'
     )
   fi
 
-  if [[ $major -lt 1 && $minor -le 27 ]];then
+  if [[ ag_version <= 0.27 ]]; then
     AG_OPTS+=(
       '--depth[Search up to NUM directories deep. Default is 25.]:number'
     )
   fi
-  if [[ $major -ge 1 || $minor -gt 27 ]];then
+  if [[ ag_version > 0.27 ]]; then
     AG_OPTS+=(
       '(-c --count)'{-c,--count}'[only print the number of matches in each file]'
       '--depth[Search up to NUM directories deep, -1 for unlimited. Default is 25.]:number'
@@ -128,12 +120,12 @@ _ag_add_version_opts() {
     )
   fi
 
-  if [[ $major -lt 1 && $minor -le 28 ]];then
+  if [[ ag_version <= 0.28 ]]; then
     AG_OPTS+=(
       '(--no-numbers)--no-numbers[don´t show line numbers]'
     )
   fi
-  if [[ $major -ge 1 || $minor -gt 28 ]];then
+  if [[ ag_version > 0.28 ]]; then
     AG_OPTS+=(
       '(--nofilename --filename)'{--nofilename,--filename}'[Print file names. Default on, except when searching a single file.]'
       '(--nonumbers --numbers)'{--nonumbers,--numbers}'[Print line numbers. Default is to omit line numbers when searching streams]'


### PR DESCRIPTION
The Silver Searcher ([ag](https://github.com/ggreer/the_silver_searcher)) is now past version 1.0 and so the logic in this completion doesn't cope properly with the fact that while the major version is past 0, the minor version is now less than expected values (testing for values in the 0.20s).

This PR adds in a func to extract the major version and then enhance the comparisons for version-specific option loading to properly account for major version values as well as minor.

This isn't, admittedly, elegant; it's possible that the completion module for `ack` does things better (by exporting version as a `x.y` value and then comparing against that so that 0.25 < 1.0). I'll try using that pattern in this PR to see if I can get it to work, but Zsh scripting is not really in my wheelhouse, so sticking closely to the stuff this completion module was already doing seemed safest.