### PR TITLE
Fix regex of ansible completion

### DIFF
--- a/src/_ansible
+++ b/src/_ansible
@@ -92,7 +92,7 @@ __host_list ()
   local -a mixed_host_list
   mixed_host_list=$(command \
     cat ${HOST_FILE} \
-    | awk 'NF && $1 !~ /^[:space:]*#|[\[:=]/ { print $1 }' \
+    | awk 'NF && $1 !~ /^[[:space:]]*#|[\[:=]/ { print $1 }' \
     | sort | uniq)
 
   # compute set difference h1 - h2


### PR DESCRIPTION
from gawk 4.0, it puts warnings for using a character class by single brace, like `[:space:]`.
This is the fix for it.
