### PR TITLE
Support to find Ansible hosts file in DebOps style projects

### DIFF
--- a/src/_ansible
+++ b/src/_ansible
@@ -62,6 +62,7 @@ __host_file_location () {
   [[ "$OSTYPE" == darwin* ]] && FALLBACK="/usr/local/etc/ansible/hosts"
   [[ "$OSTYPE" == linux* ]] && FALLBACK="/etc/ansible/hosts"
   HOST_FILE=${ANSIBLE_HOSTS:=${FALLBACK}}
+  [[ -f ${HOST_FILE} ]] || HOST_FILE="$PWD/ansible/inventory/hosts"
   [[ -f ${HOST_FILE} ]] || HOST_FILE=/dev/null
 
   echo ${HOST_FILE}

--- a/src/_ansible-playbook
+++ b/src/_ansible-playbook
@@ -61,6 +61,7 @@ __host_file_location () {
   [[ "$OSTYPE" == darwin* ]] && FALLBACK="/usr/local/etc/ansible/hosts"
   [[ "$OSTYPE" == linux* ]] && FALLBACK="/etc/ansible/hosts"
   HOST_FILE=${ANSIBLE_HOSTS:=${FALLBACK}}
+  [[ -f ${HOST_FILE} ]] || HOST_FILE="$PWD/ansible/inventory/hosts"
   [[ -f ${HOST_FILE} ]] || HOST_FILE=/dev/null
 
   echo ${HOST_FILE}


### PR DESCRIPTION
In [DebOps](https://debops.org/), it is common to have the Ansible host inventory in a projects directory below "$HOME". This allows to have multiple and separate Ansible environments. For such a setup, the host inventory can be found at `$PWD/ansible/inventory/hosts` as Ansible is typically executed from the root of the project.
This patch adds support for such a layout as fallback.

Ref: https://docs.debops.org/en/latest/debops-playbooks/docs/guides/getting-started.html