### PR TITLE
Use `sed -E` instead of `-r`

### DIFF
--- a/src/_yarn
+++ b/src/_yarn
@@ -76,13 +76,13 @@ _global_commands=(
 
 _yarn_commands_scripts() {
   local -a scripts
-  scripts=($(yarn run --json 2>/dev/null | sed -r '/Commands available|possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g;s/,/\n/g'))
+  scripts=($(yarn run --json 2>/dev/null | sed -E '/Commands available|possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g;s/,/\n/g'))
   _describe 'command or script' _commands -- _global_commands -- scripts
 }
 
 _yarn_scripts() {
   local -a scripts
-  scripts=($(yarn run --json 2>/dev/null | sed -r '/Commands available|possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g;s/,/\n/g'))
+  scripts=($(yarn run --json 2>/dev/null | sed -E '/Commands available|possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g;s/,/\n/g'))
   _describe 'script' scripts
 }
 


### PR DESCRIPTION
`-E` is more widely supported, including GNU sed.

- [GNU sed](https://www.gnu.org/software/sed/manual/sed.html)
- [macOS](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/sed.1.html)
- [FreeBSD](https://man.freebsd.org/sed/)
- [NetBSD](http://netbsd.gw.com/cgi-bin/man-cgi?sed)
- [OpenBSD](http://man.openbsd.org/sed.1)

A couple of existing completions already use it.