### PR TITLE
[WIP] _ansible-playbook - Fix multiple verbose option flag options

### DIFF
--- a/src/_ansible-playbook
+++ b/src/_ansible-playbook
@@ -169,8 +169,11 @@ _ansible-playbook ()
     "(-T --timeout)"{-T,--timeout}"[TIMEOUT override the SSH timeout (s) (default=10)]:ssh timeout:(10)"\
     "(-u --user)"{-u,--user}"[REMOTE_USER connect as this user (default=${USER})]:connect as user:(${USER})"\
     "--vault-password-file[VAULT_PASSWORD_FILE vault password file]:vault password file:_files"\
-    "(-v --verbose)"{-v,--verbose}"[verbose mode (-vvv for more, -vvvv to enable connection debugging)]"\
-    "--version[show program's version number and exit]"\
+    '(-vv -vvv -vvvv --verbose)-v[verbose mode (-vvv for more, -vvvv to enable connection debugging)]' \
+    "(-v -vvv -vvvv --verbose)-vv[verbose mode (-vvv for more, -vvvv to enable connection debugging)]" \
+    '(-v -vv -vvvv --verbose)-vvv[verbose mode (-vvv for more, -vvvv to enable connection debugging)]' \
+    '(-v -vv -vvv --verbose)-vvvv[verbose mode (-vvv for more, -vvvv to enable connection debugging)]' \
+    '(-v -vv -vvv -vvvv)--verbose[verbose mode (-vvv for more, -vvvv to enable connection debugging)]' \
 
   case $state in
     pattern)


### PR DESCRIPTION
# This PR...

...adds support for multiple grouped `-v` options in the `_ansible-playbook` completer. Submitting with `[WIP]` tag because this is still in progress and I would love some more input/suggestions on this.

**Limitations**

1. While this PR *enables* support for grouped option flags (such as `-vvv`) it does not enable multiple invocations of the same option flag (such as `-v -v -v` [equivalent to `-vvv`]).
1. Providing `--verbose` and options matching `regex('/v{1.4}/)` (e.g., `ansible-playbook --verbose -vv`, which is equivalent to `ansible-playbook -vvv`) does not work

# Feedback Requested

* Anyone have ideas for how to get multiple invocations of the same option flag to still complete? See `#1` in the list above

* Less pressing, but does anyone have any ideas for how to get `--verbose` to work **in addition** to option grouping?

# Description

The `/bin/ansible-playbooks` command accepts short option flags, e.g., `-v`, in the standard way where multiple may be adjacent to another, such as `-vv` or with an option flag which requires a positional parameter, e.g., `-vi inventory_file`. However, tab completion fails for positional parameters with the `_ansible-playbook` completion in this repository.

# Example

1. This will tab complete correctly after the `-i` parameter:
```
$ ansible-playbook -v -i ./inventory/hosts ./some/playbook.yml`
```

2. This will *not* tab complete correctly. The `-i` parameter can still auto-complete `_file` comp choices, however the positional `_file` parameter (`playbook`) for the playbook to run is unable to be tab completed. Here's the full command I would expect to complete (because it is a valid invocation of the `/bin/ansible-playbook` command):

> ansible-playbook -vv ./inventory/hosts ./some/playbook.yml

But: Auto completion only works **up to** this point (providing `-vv`, then `-i` and tab completing a `_file` for the `inventory` parameter):
```
$ ansible-playbook -vv -i ./<TAB>
```
After you provide the inventory parameter for the `-i` option the completer no longer defaults to attempting to auto-complete a file path. Instead you are prompted with more `--option` flag completions.

I am guessing from the observed behavior that the completer is parsing the second `v` in the `-vv` section as a **positional** parameter (which should be the `playbook`s `_file` completer) and assigning it to the `playbook` completion.

# Summary

* `_ansible-playbook` does not support the common method ([See 'count' under "Actions"](https://docs.python.org/2/library/argparse.html#action)) of joining multiple option flags together into a single `-option` group. 
* `_ansible-playbook` does not support providing multiple `-v` options in a single command, i.e., `-v -v -v`.
* `/bin/ansible-playbook` supports grouping multiple `-v` options together, i.e., `-vvv` is equal to `-v -v -v`.


# References

For ideas on how to tackle this I borrowed from the `_openssl` completer. I saw it has a section under the `_openssl_engine` function for handling multiple `-v` options gracefully