### PR TITLE
knife plugin cannot ls path with quotes

### DIFF
--- a/src/_knife
+++ b/src/_knife
@@ -219,7 +219,7 @@ _chef_users_remote() {
 
 # The chef_x_local functions use the knife config to find the paths of relevant objects x to be uploaded to the server
 _chef_cookbooks_local() {
- (for i in $( grep cookbook_path $HOME/.chef/knife.rb | awk 'BEGIN {FS = "[" }; {print $2}' | sed 's/\,//g' | sed "s/'//g" | sed 's/\(.*\)]/\1/' ); do ls $i; done)
+ (for i in $( grep cookbook_path $HOME/.chef/knife.rb | awk 'BEGIN {FS = "[" }; {print $2}' | sed 's/\,//g' | sed "s/'//g" | sed 's/\(.*\)]/\1/'  | cut -d '"' -f2 ); do ls $i; done)
 }
 
 # This function extracts the available cookbook versions on the chef server


### PR DESCRIPTION
The original `_chef_cookbooks_local()` has a problem on tab complete when doing `knife cookbook upload <tab>`, spit out No such file or directory error.

```bash
ls `grep cookbook_path $HOME/.chef/knife.rb | awk 'BEGIN {FS = "[" }; {print $2}' | sed 's/\,//g' | sed "s/'//g" | sed 's/\(.*\)]/\1/'`
```

output: ls: cannot access '"/home/zsh/chef-repo/cookbooks"': No such file or directory

This fixes the problem.

However this fix simple will not honour ruby syntax of `#{current_dir}`.