### PR TITLE
Add tmuxp auto-completion

### DIFF
--- a/src/_tmuxp
+++ b/src/_tmuxp
@@ -71,7 +71,7 @@ _tmuxp() {
             ;;
           (freeze)
             _arguments -C \
-              '1::session name:compadd $(command tmux ls -F "#{session_name}")'
+              '1::session name:compadd $(command tmux ls -F "#{session_name}" 2>/dev/null)'
             ;;
           (convert)
             _arguments -C \

--- a/src/_tmuxp
+++ b/src/_tmuxp
@@ -47,8 +47,8 @@ _tmuxp() {
   _arguments -C \
     ":command:->command" \
     "*::options:->options" \
-    "--log_level:Log level:(DEBUG INFO WARNING ERROR CRITICAL)" \
-    "--help:Show help"
+    "--log_level:log level:(DEBUG INFO WARNING ERROR CRITICAL)" \
+    "--help[display usage information]"
 
     case $state in
       (command)
@@ -71,7 +71,7 @@ _tmuxp() {
             ;;
           (freeze)
             _arguments -C \
-              '1:: :{_wanted tmux-sessions exp "session name" compadd $(tmux ls -F "#{session_name}")}'
+              '1::session name:compadd $(command tmux ls -F "#{session_name}")'
             ;;
           (convert)
             _arguments -C \
@@ -98,14 +98,9 @@ __tmuxp_load() {
   case $state in
     (sessions)
       local s
-      _wanted user-sessions expl 'User sessions' compadd \
-        $(
-          for file in ~/.tmuxp/*.(json|yml|yaml)
-          do
-            s=${file:t:r}
-            [[ -z "${line[(r)$s]}" ]] && echo $s
-          done)
-          _wanted sessions expl 'Other sessions' compadd $(for file in ./*.(json|yaml|yml); do echo $file; done)
+      _alternative \
+        'sessions-user:user session:compadd -F line - ~/.tmuxp/*.(json|yml|yaml)(:r:t)' \
+        'sessions-other:session in current directory:_path_files -g "**/*.(json|yaml|yml)(-.)"'
       ;;
   esac
 }

--- a/src/_tmuxp
+++ b/src/_tmuxp
@@ -1,0 +1,131 @@
+#compdef tmuxp
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 Github zsh-users - http://github.com/zsh-users
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the zsh-users nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL ZSH-USERS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for tmuxp (https://tmuxp.git-pull.com/en/latest/)
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Bez Hermoso <bezalelhermoso@gmail.com>
+#
+# ------------------------------------------------------------------------------
+
+_tmuxp() {
+
+  local curcontext="$curcontext" state line
+  typeset -A opt_args
+
+  _arguments -C \
+    ":command:->command" \
+    "*::options:->options" \
+    "--log_level:Log level:(DEBUG INFO WARNING ERROR CRITICAL)" \
+    "--help:Show help"
+
+    case $state in
+      (command)
+        local -a subcommands
+        subcommands=(
+        'convert:Convert a tmuxp config between JSON and YAML.'
+        'freeze:Snapshot a session into a config.'
+        'import:Import a teamocil/tmuxinator config.'
+        'load:Load tmuxp workspaces.'
+        )
+        _describe -t commands 'commands' subcommands
+        ;;
+      (options)
+        case $line[1] in
+          (load)
+            __tmuxp_load
+            ;;
+          (import)
+            __tmuxp_import
+            ;;
+          (freeze)
+            _arguments -C \
+              '1:: :{_wanted tmux-sessions exp "session name" compadd $(tmux ls -F "#{session_name}")}'
+            ;;
+          (convert)
+            _arguments -C \
+              '1:: :_files -g "*.(json|yaml|yml)"'
+            ;;
+        esac
+    esac
+
+}
+
+__tmuxp_load() {
+  local state line
+  typeset -A opt_args
+  _arguments -C \
+    '*:sessions:->sessions' \
+    '--yes:yes' \
+    '-d[Load the session without attaching it]' \
+    '-2[Force tmux to assume the terminal supports 256 colors]' \
+    '-8[Like -2, but indicates that the terminal supports 88 colors]'
+
+  # Cant get the options to be recognized when there are sessions that has
+  # a dash.
+
+  case $state in
+    (sessions)
+      local s
+      _wanted user-sessions expl 'User sessions' compadd \
+        $(
+          for file in ~/.tmuxp/*.(json|yml|yaml)
+          do
+            s=${file:t:r}
+            [[ -z "${line[(r)$s]}" ]] && echo $s
+          done)
+          _wanted sessions expl 'Other sessions' compadd $(for file in ./*.(json|yaml|yml); do echo $file; done)
+      ;;
+  esac
+}
+
+__tmuxp_import() {
+  local state line
+  typeset -A opt_args
+  _arguments -C \
+    '1::program:(tmuxinator teamocil)' \
+    '2::project:->project'
+
+  case $state in
+    (project)
+      if [[ $line[1] == 'tmuxinator' ]]
+      then
+        _wanted tmuxinator-projects exp 'tmuxinator projects' compadd $(tmuxinator completions start)
+      fi
+      ;;
+  esac
+}
+
+_tmuxp "$@"
+

--- a/src/_tmuxp
+++ b/src/_tmuxp
@@ -70,8 +70,9 @@ _tmuxp() {
             __tmuxp_import
             ;;
           (freeze)
+            local sessions="$(__tmux_sessions)"
             _arguments -C \
-              '1::session name:compadd $(command tmux ls -F "#{session_name}" 2>/dev/null)'
+              "1::session name:compadd $sessions"
             ;;
           (convert)
             _arguments -C \
@@ -120,6 +121,12 @@ __tmuxp_import() {
       fi
       ;;
   esac
+}
+
+__tmux_sessions () {
+  local tmux_sessions
+  tmux_sessions=($(_call_program tmux_sessions 'tmux ls -F "#{session_name}"'))
+  echo $tmux_sessions
 }
 
 _tmuxp "$@"


### PR DESCRIPTION
* Command auto-completion for `convert`, `freeze`, `import`, and `load`.
* Auto-complete sessions stored in `~/.tmuxp` and current directory.
* Auto-complete for `import tmuxinator` support completion of tmuxinator projects. 