### PR TITLE
add CMAKE_PREFIX_PATH to cmake completion

### DIFF
--- a/src/_cmake
+++ b/src/_cmake
@@ -302,7 +302,8 @@ _cmake_define_lang_property_names() {
 (( $+functions[_cmake_define_common_property_names] )) ||
 _cmake_define_common_property_names() {
   local properties; properties=(
-    'CMAKE_MODULE_PATH:Search path for cmake modules'
+    'CMAKE_MODULE_PATH:Search path for cmake modules (FindPROJECT.cmake)'
+    'CMAKE_PREFIX_PATH:Search path for installations (PROJECTConfig.cmake)'
     'CMAKE_BUILD_TYPE:Specifies the build type for make based generators'
     'CMAKE_TOOLCHAIN_FILE:Absolute or relative path to a cmake script which sets up toolchain related variables'
     'CMAKE_COLOR_MAKEFILE:Enables/disables color output when using the Makefile generator'


### PR DESCRIPTION
https://cmake.org/cmake/help/v3.3/variable/CMAKE_PREFIX_PATH.html
 * some packages provide no Find${PROJECT}.cmake file but a ${PROJECT}Config.cmake instead
 * providing these through CMAKE_MODULE_PATH just results in an error
   message, which points out one should've used CMAKE_PREFIX_PATH instead.
at least that's the behaviour I just observed with
https://crackingtheloop.wordpress.com/2016/09/17/installing-range-v3/