### PR TITLE
improve tmuxp load completions

### DIFF
--- a/src/_tmuxp
+++ b/src/_tmuxp
@@ -101,7 +101,8 @@ __tmuxp_load() {
       local s
       _alternative \
         'sessions-user:user session:compadd -F line - ~/.tmuxp/*.(json|yml|yaml)(:r:t)' \
-        'sessions-other:session in current directory:_path_files -g "**/*.(json|yaml|yml)(-.)"'
+        'sessions-other:session in current directory:_path_files -/ -g "**/.tmuxp.(yml|yaml|json)"' \
+        'sessions-other:session in current directory:_path_files -g "*.(yml|yaml|json)"'
       ;;
   esac
 }


### PR DESCRIPTION
``'sessions-other:session in current directory:_path_files -g "**/*.(json|yaml|yml)(-.)"'`` can cause a hang with traversing directories and leave the shell inoperable for a few seconds. After the lock up ends, it may either ring the system bell, or return any directory containing a json or yaml file.

This patch limits ``*.(json|yaml|yml)(-.)`` to the current directory to eliminate the hang, while still allowing to complete files. It also uses double splats, but only for finding directories with ``.tmuxp(json/yaml/yml)`` files, which is faster and more accurate. Normal directory completion is also preserved.

1. Limit wildcard json/yaml file matches to current directory
2. Preserve all directory completion (for tabbing into directories)
3. Use unlimited depth search for directories with .tmuxp.(yaml/json)
   inside them. tmuxp load command can load the file or the directory.
4. Preserves behavior of finding files in ``$HOME/.tmuxp``