### PR TITLE
fix "arguments:448: _vim_files: function definition file not found" error

### DIFF
--- a/src/_vim_files
+++ b/src/_vim_files
@@ -1,0 +1,61 @@
+#!/usr/bin/env zsh
+# ------------------------------------------------------------------------------
+# Copyright (c) 2011 Github zsh-users - http://github.com/zsh-users
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the zsh-users nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL ZSH-USERS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for _vim_files
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Hector Lecuanda (https://github.com/hlecuanda)
+#
+#  Based on code for _jq completion by:
+#  * Hideaki Miyake (https://github.com/mollifier)
+#  * George Kontridze (https://github.com/gkze)
+#
+# ------------------------------------------------------------------------------
+
+declare -a opts
+local curcontext=$curcontext state line ret=1
+declare -A opt_args
+
+_arguments -C $opts \
+  $args && ret=0
+
+case $state in
+  *)
+    _files && ret=0
+    ;;
+esac
+
+return $ret
+
+
+#  vim: set ft=zsh sw=2 tw=0 fdm=manual et :


### PR DESCRIPTION
I'm not sure if this is the correct place, but it seems as good an upstream as any. 

It's been a fairly recurrent issue to suddenly bump into the error  `_arguments:448: _vim_files: function definition file not found ` as can be seen by googling [`"_vim_files" zsh`](https://www.google.com/search?q="_vim_files"+zsh&oq="_vim_files"+zsh)

I've seen instances of this issue since 2008 (!) and the solution has been to "delete `.zcompdump`" (?) of course this only hides the error until `zcompile` is run again, so i'm submitting this `_vim_files` so hopefully this issue can be put to rest in a way that does not negate the benefits of a compiled completion digest.

Based on the current `_jq` completion it seems to do the job. 

