### PR TITLE
Fix outdated references to "macOS" as "OS X", "Mac OS X", etc.

### DIFF
--- a/src/_ansible
+++ b/src/_ansible
@@ -40,7 +40,7 @@
 # ------------------------------------------------------------------------------
 #
 # Needs either ANSIBLE_HOSTS or /etc/ansible/hosts on linux
-# (or /usr/local/etc/ansible/hosts on OSX)
+# (or /usr/local/etc/ansible/hosts on macOS)
 #
 # Note 1: the following gist (https://gist.github.com/15ed54a438a36d67fd99.git)
 # has some files to help improve the hostfile shell parsing
@@ -416,8 +416,8 @@ _modules=(
 'os_user:Manage OpenStack Identity Users'
 'os_user_group:Associate OpenStack Identity users and groups'
 'os_volume:Create/Delete Cinder Volumes'
-'osx_defaults:osx_defaults allows users to read, write, and delete Mac OS X user defaults from Ansible'
-'osx_say:Makes an OSX computer to speak.'
+'osx_defaults:osx_defaults allows users to read, write, and delete macOS user defaults from Ansible'
+'osx_say:Makes a macOS computer speak.'
 'ovirt:oVirt/RHEV platform management'
 'package:Generic OS package manager'
 'pacman:Manage packages with *pacman*'

--- a/src/_ansible-playbook
+++ b/src/_ansible-playbook
@@ -40,7 +40,7 @@
 # ------------------------------------------------------------------------------
 #
 # Needs either ANSIBLE_HOSTS or /etc/ansible/hosts on linux
-# (or /usr/local/etc/ansible/hosts on OSX)
+# (or /usr/local/etc/ansible/hosts on macOS)
 #
 # Note 1: the following gist (https://gist.github.com/15ed54a438a36d67fd99.git)
 # has some files to help improve the hostfile shell parsing

--- a/src/_caffeinate
+++ b/src/_caffeinate
@@ -28,7 +28,7 @@
 # Description
 # -----------
 #
-#  Completion script for the OSX 'caffeinate' tool (man 8 caffeinate).
+#  Completion script for the macOS 'caffeinate' tool (man 8 caffeinate).
 #
 # -------------------------------------------------------------------------
 # Authors

--- a/src/_ghc
+++ b/src/_ghc
@@ -92,15 +92,15 @@ _ghc_compiler ()
         '-c[Stop after generating object files]' \
         '-eventlog[Enable runtime event tracing]' \
         '-debug[Use the debugging runtime]' \
-        "-dylib-install-name[On Darwin/OS X only, set the install name]" \
+        "-dylib-install-name[On Darwin/macOS only, set the install name]" \
         '-dynamic[Use dynamic Haskell libraries]' \
         '-dynamic-too[Build dynamic object files as well as static object files during compilation]' \
         '-dynosuf[Set the output suffix for dynamic object files]' \
         '-dynload[Select one of a number of modes for finding shared libraries at runtime]' \
         '--mk-dll[DLL-creation mode (Windows only)]' \
-        '-framework-path[On Darwin/OS X/iOS only, add dir to the list of directories searched for frameworks]' \
+        '-framework-path[On Darwin/macOS/iOS only, add dir to the list of directories searched for frameworks]' \
         '-shared[Generate a shared library (as opposed to an executable)]' \
-        '-staticlib[On Darwin/OS X/iOS only, generate a standalone static library (as opposed to an executable)]' \
+        '-staticlib[On Darwin/macOS/iOS only, generate a standalone static library (as opposed to an executable)]' \
         '-e[Evaluate expression]' \
         '-hide-all-packages[Hide all packages by default]' \
         '-hpcdir[Directory to deposit .mix files during compilation (default is .hpc)]' \

--- a/src/_port
+++ b/src/_port
@@ -157,7 +157,7 @@ _port() {
     '-F[Read and process the file of commands specified by the argument.]' \
     '-p[Despite any errors encountered, proceed to process multiple ports and commands.]' \
     '-y[Perform a dry run.]' \
-    '-t[Enable trace mode debug facilities on platforms that support it (Mac OS X).]' \
+    '-t[Enable trace mode debug facilities on platforms that support it (macOS).]' \
     "1:Port actions:(($actions))" \
     '::Per-action arguments:_port_dispatch' \
     && return 0


### PR DESCRIPTION
Apple [renamed "Mac OS X" to "macOS" in 2016](https://www.wired.com/2016/06/apple-os-x-dead-long-live-macos/). This *extremely important*¹ PR fixes the outdated references.

* Replace instances of "OSX"/"OS X"/etc. with "macOS" in comments to reflect the change.
* There are additional references to things like "osx" in functional code which are left unchanged.
* Grammatical changes due to the initial letter changing from a vowel to a consonant (o => m) in some places.
* Fix a unrelated minor grammatical issue.

1. Sarcasm, if it wasn't obvious.