### PR TITLE
Add MacPorts link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See [issues](https://github.com/zsh-users/zsh-completions/issues) for details on
 | Gentoo | [app-shells/zsh-completions](http://packages.gentoo.org/package/app-shells/zsh-completions)  |
 | NixOS | [zsh-completions](https://github.com/NixOS/nixpkgs/blob/master/pkgs/shells/zsh-completions/default.nix) |
 | Void Linux | [zsh-completions](https://github.com/voidlinux/void-packages/tree/master/srcpkgs/zsh-completions) |
-| Mac OS | [homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/zsh-completions.rb)  |
+| Mac OS | [homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/zsh-completions.rb), [MacPorts](https://github.com/macports/macports-ports/blob/master/sysutils/zsh-completions/Portfile)  |
 
 ### Using zsh frameworks
 


### PR DESCRIPTION
Like Homebrew, MacPorts also has a `zsh-completions` package for Mac OS.