### PR TITLE
Fix kakoune completion not providing a description argument to _values

### DIFF
--- a/src/_kak
+++ b/src/_kak
@@ -43,7 +43,7 @@
 
 _kak_sessions() {
   session_ids=($(_call_program session_ids kak -l))
-  _values "${session_ids[@]}"
+  _values 'kak sessions' "${session_ids[@]}"
 }
 
 _kak() {

--- a/src/_kak
+++ b/src/_kak
@@ -42,8 +42,10 @@
 # ------------------------------------------------------------------------------
 
 _kak_sessions() {
-  session_ids=($(_call_program session_ids kak -l))
-  _values 'kak sessions' "${session_ids[@]}"
+  local -a session_ids expl
+  session_ids=($(_call_program session_names kak -l))
+  _description session-ids expl "session name"
+  compadd "$expl[@]" -a session_ids
 }
 
 _kak() {


### PR DESCRIPTION
Using zsh 5.4.2, I occasionally run into an error "_values:compvalues:11: not enough arguments". When it doesn't occur, instead, one of the kakoune sessions is missing from autocompletion.

I believe this is because _values was treating the first session id as a description. As http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Completion-System describes, "The first non-option argument is used as a string to print as a description before listing the values. "

This fixes that by providing a description manually.