### PR TITLE
Completions How To's Typo Fix So second _regex_arguments example works

### DIFF
--- a/zsh-completions-howto.org
+++ b/zsh-completions-howto.org
@@ -271,7 +271,7 @@ except that it has an extra : at the start, and now all of the possible ACTION f
 
 Here is an example:
 #+BEGIN_SRC sh 
-_regex_arguments _hello /$'[^\0]##\0'/ \( /$'word1(a|b|c)\0'/ ':word:first word:(word1a word1b word1c)' '|'\
+_regex_arguments _cmd /$'[^\0]##\0'/ \( /$'word1(a|b|c)\0'/ ':word:first word:(word1a word1b word1c)' '|'\
    /$'word11(a|b|c)\0'/ ':word:first word:(word11a word11b word11c)' \( /$'word2(a|b|c)\0'/ ':word:second word:(word2a word2b word2c)'\
    '|' /$'word22(a|b|c)\0'/ ':word:second word:(word22a word22b word22c)' \) \)
 _cmd "$@"


### PR DESCRIPTION

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [ ] This compdef is not already available in zsh.
- [ ] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [ ] It has a header containing authors, status and origin of the script.
- [ ] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
