### PR TITLE
Fix typos in _trash-put

### DIFF
--- a/src/_trash-put
+++ b/src/_trash-put
@@ -42,10 +42,10 @@
 _arguments -C \
   '--version[display version information]' \
   {-h,--help}'[display usage information]' \
-  {-d,--directory}'[remove empty directories - ignored (for GNU rm compabilty)]' \
-  {-f,--force}'[ignore nonexistent arguments and never prompt - ignored (for GNU rm compabilty)]' \
+  {-d,--directory}'[remove empty directories - ignored (for GNU rm compatibility)]' \
+  {-f,--force}'[ignore nonexistent arguments and never prompt - ignored (for GNU rm compatibility)]' \
   {-i,--interactive}'[prompt before every removal - ignored (for GNU rm compabilty)]' \
-  {-r,-R,--recursive}'[remove directories and their content recursively - ignored (for GNU rm compabilty)]' \
+  {-r,-R,--recursive}'[remove directories and their content recursively - ignored (for GNU rm compatibility)]' \
   {-v,--verbose}'[explain what is being done]' \
   '*: :_files'
 


### PR DESCRIPTION
It's currently saying "compabilty" instead of "compatibility".

Also, thanks for all you efforts, you're the ones making zsh my favourite shell o/