### PR TITLE
Update _rvm

### DIFF
--- a/src/_rvm
+++ b/src/_rvm
@@ -48,7 +48,7 @@ _arguments -C \
   '--nice[process niceness (for slow computers, default 0)]:number' \
   '--ree-options[Options passed directly to ree ./installer on the command line]:options' \
   '--head[with update, updates rvm to git head version]' \
-  '--rubygems[with update, updates rubygems for selected ruby]' \
+  '-r rubygems[with update, updates rubygems for selected ruby]' \
   '--default[with ruby select, sets a default ruby for new shells]' \
   '--debug[Toggle debug mode on for very verbose output]' \
   '--trace[Toggle trace mode on to see EVERYTHING rvm is doing]' \


### PR DESCRIPTION
Update parameter for `ruby`.

`-rubygems` is deprecated 

```'-rubygems.rb' is deprecated, and will be removed on or after 2018-12-01. Remove `-rubygems' from your command-line, or use `-r rubygems' instead  ```
