### PR TITLE
git-flow: remove non-existing subcommand

### DIFF
--- a/src/_git-flow
+++ b/src/_git-flow
@@ -60,7 +60,6 @@ _git-flow ()
 				'hotfix:Manage your hotfix branches.'
 				'support:Manage your support branches.'
 				'version:Shows version information.'
-				'status:Shows some status.'
 			)
 			_describe -t commands 'git flow' subcommands
 		;;


### PR DESCRIPTION
git-flow calls a subcommand based on filename, see [the code of git-flow](https://github.com/nvie/gitflow/blob/15aab26490facf285acef56cb5d61025eacb3a69/git-flow#L91-L97).
But git-flow-status doesn't exist on git-flow repository.

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->