### PR TITLE
edit README.md: use `$ZSH_CUSTOM` if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add `antigen bundle zsh-users/zsh-completions` to your `~/.zshrc`.
 
 * Clone the repository inside your oh-my-zsh repo:
 
-        git clone https://github.com/zsh-users/zsh-completions ~/.oh-my-zsh/custom/plugins/zsh-completions
+        git clone https://github.com/zsh-users/zsh-completions ${ZSH_CUSTOM:=~/.oh-my-zsh/custom}/plugins/zsh-completions
 
 * Enable it in your `.zshrc` by adding it to your plugin list and reloading the completion:
 


### PR DESCRIPTION
`${ZSH_CUSTOM:=~/.oh-my-zsh/custom}` would use value of `$ZSH_CUSTOM` if it exists. Otherwise it falls back to `~/.oh-my-zsh/custom`.

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->
