### PR TITLE
hardcode location of command stat for macOS

### DIFF
--- a/src/_vagrant
+++ b/src/_vagrant
@@ -133,8 +133,8 @@ _vagrant_caching_policy()
             ;;
     esac
 
-    case $(uname -s) in
-        Darwin) STATCMD="stat -f '%c'" ;;
+    case "$OSTYPE" in
+        darwin*) STATCMD="/usr/bin/stat -f '%c'" ;;
         *)      STATCMD="stat -c '%Z'" ;;
     esac
     reg_time=${$(${(z)STATCMD} $check_file):Q}


### PR DESCRIPTION
I know a lot of guys use GNU commands instead of BSD commands on
macOS. Hardcoding `/usr/bin/stat` to bypass `stat` from `coreutils` makes
the completion more compatible. I don't see any side effect for the time being.

Besides, `$OSTYPE` is used to replace `$(uname -s)`, which should be faster.

[Use "$OSTYPE" instead of "$(uname)" for OS detection.](https://github.com/dylanaraps/neofetch/issues/433)