### PR TITLE
[cmake] complete CMAKE_GENERATOR environment variable values

### DIFF
--- a/src/_cmake
+++ b/src/_cmake
@@ -1,4 +1,4 @@
-#compdef cmake
+#compdef cmake -value-,CMAKE_GENERATOR,-default-
 # ------------------------------------------------------------------------------
 # Copyright (c) 2017 Github zsh-users - http://github.com/zsh-users
 # All rights reserved.
@@ -455,7 +455,9 @@ local cmake_suggest_build;cmake_suggest_build=(
     '--build[build]:build dir:_cmake_suggest_builddirs'
 )
 
-if [ $CURRENT -eq 2 ] ; then
+if [[ "$service" = -value-*CMAKE_GENERATOR* ]]; then
+  _cmake_generators
+elif [ $CURRENT -eq 2 ] ; then
   _arguments -C -s \
     - help \
       "$cmake_help_actions[@]" \


### PR DESCRIPTION
this environment variable will be introduced in cmake 3.15
https://cmake.org/cmake/help/v3.15/manual/cmake-env-variables.7.html#environment-variables-that-control-the-build

At the moment it's a bit bodged in as there is no broad idea for value completion in _cmake.

For now it's okay, I guess, but should there be desire to cover all cmake environment variables that should probably be reworked a bit.