### PR TITLE
Add support for Swift completion

### DIFF
--- a/src/_swift
+++ b/src/_swift
@@ -1,0 +1,474 @@
+#compdef swift
+local context state state_descr line
+typeset -A opt_args
+
+_swift() {
+    _arguments -C \
+        '(- :)--help[prints the synopsis and a list of the most commonly used commands]: :->arg' \
+        '(-): :->command' \
+        '(-)*:: :->arg' && return
+
+    case $state in
+        (command)
+            local tools
+            tools=(
+                'build:build sources into binary products'
+                'run:build and run an executable product'
+                'package:perform operations on Swift packages'
+                'test:build and run tests'
+            )
+            _alternative \
+                'tools:common:{_describe "tool" tools }' \
+                'compiler: :_swift_compiler' && _ret=0
+            ;;
+        (arg)
+            case ${words[1]} in
+                (build)
+                    _swift_build
+                    ;;
+                (run)
+                    _swift_run
+                    ;;
+                (package)
+                    _swift_package
+                    ;;
+                (test)
+                    _swift_test
+                    ;;
+                (*)
+                    _swift_compiler
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_swift_dependency() {
+    local dependencies
+    dependencies=( $(swift package completion-tool list-dependencies) )
+    _describe '' dependencies
+}
+
+_swift_executable() {
+    local executables
+    executables=( $(swift package completion-tool list-executables) )
+    _describe '' executables
+}
+
+# Generates completions for swift build
+#
+# In the final compdef file, set the following file header:
+#
+#     #compdef _swift_build
+#     local context state state_descr line
+#     typeset -A opt_args
+_swift_build() {
+    arguments=(
+        "-Xcc[Pass flag through to all C compiler invocations]:Pass flag through to all C compiler invocations: "
+        "-Xswiftc[Pass flag through to all Swift compiler invocations]:Pass flag through to all Swift compiler invocations: "
+        "-Xlinker[Pass flag through to all linker invocations]:Pass flag through to all linker invocations: "
+        "-Xcxx[Pass flag through to all C++ compiler invocations]:Pass flag through to all C++ compiler invocations: "
+        "(--configuration -c)"{--configuration,-c}"[Build with configuration (debug|release) ]: :{_values '' 'debug[build with DEBUG configuration]' 'release[build with RELEASE configuration]'}"
+        "--build-path[Specify build/cache directory ]:Specify build/cache directory :_files"
+        "(--chdir -C)"{--chdir,-C}"[]: :_files"
+        "--package-path[Change working directory before any other operation]:Change working directory before any other operation:_files"
+        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]' 'undefined[enable Undefined Behavior sanitizer]'}"
+        "--disable-prefetching[]"
+        "--skip-update[Skip updating dependencies from their remote during a resolution]"
+        "--disable-sandbox[Disable using the sandbox when executing subprocesses]"
+        "--disable-package-manifest-caching[Disable caching Package.swift manifests]"
+        "--version[]"
+        "--destination[]: :_files"
+        "(--verbose -v)"{--verbose,-v}"[Increase verbosity of informational output]"
+        "--no-static-swift-stdlib[Do not link Swift stdlib statically \[default\]]"
+        "--static-swift-stdlib[Link Swift stdlib statically]"
+        "--force-resolved-versions[]"
+        "--disable-automatic-resolution[Disable automatic resolution if Package.resolved file is out-of-date]"
+        "--enable-index-store[Enable indexing-while-building feature]"
+        "--disable-index-store[Disable indexing-while-building feature]"
+        "--enable-pubgrub-resolver[\[Experimental\] Enable the new Pubgrub dependency resolver]"
+        "--enable-parseable-module-interfaces[]"
+        "--trace-resolver[]"
+        "(--jobs -j)"{--jobs,-j}"[The number of jobs to spawn in parallel during the build process]:The number of jobs to spawn in parallel during the build process: "
+        "--enable-test-discovery[Enable test discovery on platforms without Objective-C runtime]"
+        "--build-tests[Build both source and test targets]"
+        "--product[Build the specified product]:Build the specified product: "
+        "--target[Build the specified target]:Build the specified target: "
+        "--show-bin-path[Print the binary output path]"
+    )
+    _arguments $arguments && return
+}
+
+# Generates completions for swift run
+#
+# In the final compdef file, set the following file header:
+#
+#     #compdef _swift_run
+#     local context state state_descr line
+#     typeset -A opt_args
+_swift_run() {
+    arguments=(
+        ":The executable to run:_swift_executable"
+        "-Xcc[Pass flag through to all C compiler invocations]:Pass flag through to all C compiler invocations: "
+        "-Xswiftc[Pass flag through to all Swift compiler invocations]:Pass flag through to all Swift compiler invocations: "
+        "-Xlinker[Pass flag through to all linker invocations]:Pass flag through to all linker invocations: "
+        "-Xcxx[Pass flag through to all C++ compiler invocations]:Pass flag through to all C++ compiler invocations: "
+        "(--configuration -c)"{--configuration,-c}"[Build with configuration (debug|release) ]: :{_values '' 'debug[build with DEBUG configuration]' 'release[build with RELEASE configuration]'}"
+        "--build-path[Specify build/cache directory ]:Specify build/cache directory :_files"
+        "(--chdir -C)"{--chdir,-C}"[]: :_files"
+        "--package-path[Change working directory before any other operation]:Change working directory before any other operation:_files"
+        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]' 'undefined[enable Undefined Behavior sanitizer]'}"
+        "--disable-prefetching[]"
+        "--skip-update[Skip updating dependencies from their remote during a resolution]"
+        "--disable-sandbox[Disable using the sandbox when executing subprocesses]"
+        "--disable-package-manifest-caching[Disable caching Package.swift manifests]"
+        "--version[]"
+        "--destination[]: :_files"
+        "(--verbose -v)"{--verbose,-v}"[Increase verbosity of informational output]"
+        "--no-static-swift-stdlib[Do not link Swift stdlib statically \[default\]]"
+        "--static-swift-stdlib[Link Swift stdlib statically]"
+        "--force-resolved-versions[]"
+        "--disable-automatic-resolution[Disable automatic resolution if Package.resolved file is out-of-date]"
+        "--enable-index-store[Enable indexing-while-building feature]"
+        "--disable-index-store[Disable indexing-while-building feature]"
+        "--enable-pubgrub-resolver[\[Experimental\] Enable the new Pubgrub dependency resolver]"
+        "--enable-parseable-module-interfaces[]"
+        "--trace-resolver[]"
+        "(--jobs -j)"{--jobs,-j}"[The number of jobs to spawn in parallel during the build process]:The number of jobs to spawn in parallel during the build process: "
+        "--enable-test-discovery[Enable test discovery on platforms without Objective-C runtime]"
+        "--skip-build[Skip building the executable product]"
+        "--build-tests[Build both source and test targets]"
+        "--repl[Launch Swift REPL for the package]"
+    )
+    _arguments $arguments && return
+}
+
+# Generates completions for swift package
+#
+# In the final compdef file, set the following file header:
+#
+#     #compdef _swift_package
+#     local context state state_descr line
+#     typeset -A opt_args
+_swift_package() {
+    arguments=(
+        "-Xcc[Pass flag through to all C compiler invocations]:Pass flag through to all C compiler invocations: "
+        "-Xswiftc[Pass flag through to all Swift compiler invocations]:Pass flag through to all Swift compiler invocations: "
+        "-Xlinker[Pass flag through to all linker invocations]:Pass flag through to all linker invocations: "
+        "-Xcxx[Pass flag through to all C++ compiler invocations]:Pass flag through to all C++ compiler invocations: "
+        "(--configuration -c)"{--configuration,-c}"[Build with configuration (debug|release) ]: :{_values '' 'debug[build with DEBUG configuration]' 'release[build with RELEASE configuration]'}"
+        "--build-path[Specify build/cache directory ]:Specify build/cache directory :_files"
+        "(--chdir -C)"{--chdir,-C}"[]: :_files"
+        "--package-path[Change working directory before any other operation]:Change working directory before any other operation:_files"
+        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]' 'undefined[enable Undefined Behavior sanitizer]'}"
+        "--disable-prefetching[]"
+        "--skip-update[Skip updating dependencies from their remote during a resolution]"
+        "--disable-sandbox[Disable using the sandbox when executing subprocesses]"
+        "--disable-package-manifest-caching[Disable caching Package.swift manifests]"
+        "--version[]"
+        "--destination[]: :_files"
+        "(--verbose -v)"{--verbose,-v}"[Increase verbosity of informational output]"
+        "--no-static-swift-stdlib[Do not link Swift stdlib statically \[default\]]"
+        "--static-swift-stdlib[Link Swift stdlib statically]"
+        "--force-resolved-versions[]"
+        "--disable-automatic-resolution[Disable automatic resolution if Package.resolved file is out-of-date]"
+        "--enable-index-store[Enable indexing-while-building feature]"
+        "--disable-index-store[Disable indexing-while-building feature]"
+        "--enable-pubgrub-resolver[\[Experimental\] Enable the new Pubgrub dependency resolver]"
+        "--enable-parseable-module-interfaces[]"
+        "--trace-resolver[]"
+        "(--jobs -j)"{--jobs,-j}"[The number of jobs to spawn in parallel during the build process]:The number of jobs to spawn in parallel during the build process: "
+        "--enable-test-discovery[Enable test discovery on platforms without Objective-C runtime]"
+        '(-): :->command'
+        '(-)*:: :->arg'
+    )
+    _arguments $arguments && return
+    case $state in
+        (command)
+            local modes
+            modes=(
+                'update:Update package dependencies'
+                'init:Initialize a new package'
+                'describe:Describe the current package'
+                'tools-version:Manipulate tools version of the current package'
+                'completion-tool:Completion tool (for shell completions)'
+                'resolve:Resolve package dependencies'
+                'edit:Put a package in editable mode'
+                'fetch:'
+                'clean:Delete build artifacts'
+                'config:Manipulate configuration of the package'
+                'unedit:Remove a package from editable mode'
+                'generate-xcodeproj:Generates an Xcode project'
+                'reset:Reset the complete cache/build directory'
+                'show-dependencies:Print the resolved dependency graph'
+                'dump-package:Print parsed Package.swift as JSON'
+            )
+            _describe "mode" modes
+            ;;
+        (arg)
+            case ${words[1]} in
+                (update)
+                    _swift_package_update
+                    ;;
+                (init)
+                    _swift_package_init
+                    ;;
+                (describe)
+                    _swift_package_describe
+                    ;;
+                (tools-version)
+                    _swift_package_tools-version
+                    ;;
+                (completion-tool)
+                    _swift_package_completion-tool
+                    ;;
+                (resolve)
+                    _swift_package_resolve
+                    ;;
+                (edit)
+                    _swift_package_edit
+                    ;;
+                (fetch)
+                    _swift_package_fetch
+                    ;;
+                (clean)
+                    _swift_package_clean
+                    ;;
+                (config)
+                    _swift_package_config
+                    ;;
+                (unedit)
+                    _swift_package_unedit
+                    ;;
+                (generate-xcodeproj)
+                    _swift_package_generate-xcodeproj
+                    ;;
+                (reset)
+                    _swift_package_reset
+                    ;;
+                (show-dependencies)
+                    _swift_package_show-dependencies
+                    ;;
+                (dump-package)
+                    _swift_package_dump-package
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_swift_package_update() {
+    arguments=(
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_init() {
+    arguments=(
+        "--type[empty|library|executable|system-module|manifest]: :{_values '' 'empty[generates an empty project]' 'library[generates project for a dynamic library]' 'executable[generates a project for a cli executable]' 'system-module[generates a project for a system module]'}"
+        "--name[Provide custom package name]:Provide custom package name: "
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_describe() {
+    arguments=(
+        "--type[json|text]: :{_values '' 'text[describe using text format]' 'json[describe using JSON format]'}"
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_tools-version() {
+    arguments=(
+        "--set[Set tools version of package to the given value]:Set tools version of package to the given value: "
+        "--set-current[Set tools version of package to the current tools version in use]"
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_completion-tool() {
+    arguments=(
+        ": :{_values '' 'generate-bash-script[generate Bash completion script]' 'generate-zsh-script[generate Bash completion script]' 'list-dependencies[list all dependencies' names]' 'list-executables[list all executables' names]'}"
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_resolve() {
+    arguments=(
+        ":The name of the package to resolve:_swift_dependency"
+        "--version[The version to resolve at]:The version to resolve at: "
+        "--branch[The branch to resolve at]:The branch to resolve at: "
+        "--revision[The revision to resolve at]:The revision to resolve at: "
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_edit() {
+    arguments=(
+        ":The name of the package to edit:_swift_dependency"
+        "--revision[The revision to edit]:The revision to edit: "
+        "--branch[The branch to create]:The branch to create: "
+        "--path[Create or use the checkout at this path]:Create or use the checkout at this path:_files"
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_fetch() {
+    arguments=(
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_clean() {
+    arguments=(
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_config() {
+    arguments=(
+        '(-): :->command'
+        '(-)*:: :->arg'
+    )
+    _arguments $arguments && return
+    case $state in
+        (command)
+            local modes
+            modes=(
+                'set-mirror:Set a mirror for a dependency'
+                'unset-mirror:Remove an existing mirror'
+                'get-mirror:Print mirror configuration for the given package dependency'
+            )
+            _describe "mode" modes
+            ;;
+        (arg)
+            case ${words[1]} in
+                (set-mirror)
+                    _swift_package_config_set-mirror
+                    ;;
+                (unset-mirror)
+                    _swift_package_config_unset-mirror
+                    ;;
+                (get-mirror)
+                    _swift_package_config_get-mirror
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_swift_package_config_set-mirror() {
+    arguments=(
+        "--package-url[The package dependency url]:The package dependency url: "
+        "--mirror-url[The mirror url]:The mirror url: "
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_config_unset-mirror() {
+    arguments=(
+        "--package-url[The package dependency url]:The package dependency url: "
+        "--mirror-url[The mirror url]:The mirror url: "
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_config_get-mirror() {
+    arguments=(
+        "--package-url[The package dependency url]:The package dependency url: "
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_unedit() {
+    arguments=(
+        ":The name of the package to unedit:_swift_dependency"
+        "--force[Unedit the package even if it has uncommited and unpushed changes.]"
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_generate-xcodeproj() {
+    arguments=(
+        "--xcconfig-overrides[Path to xcconfig file]:Path to xcconfig file:_files"
+        "--enable-code-coverage[Enable code coverage in the generated project]"
+        "--output[Path where the Xcode project should be generated]:Path where the Xcode project should be generated:_files"
+        "--legacy-scheme-generator[Use the legacy scheme generator]"
+        "--watch[Watch for changes to the Package manifest to regenerate the Xcode project]"
+        "--skip-extra-files[Do not add file references for extra files to the generated Xcode project]"
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_reset() {
+    arguments=(
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_show-dependencies() {
+    arguments=(
+        "--format[text|dot|json|flatlist]: :{_values '' 'text[list dependencies using text format]' 'dot[list dependencies using dot format]' 'json[list dependencies using JSON format]'}"
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_dump-package() {
+    arguments=(
+    )
+    _arguments $arguments && return
+}
+
+# Generates completions for swift test
+#
+# In the final compdef file, set the following file header:
+#
+#     #compdef _swift_test
+#     local context state state_descr line
+#     typeset -A opt_args
+_swift_test() {
+    arguments=(
+        "-Xcc[Pass flag through to all C compiler invocations]:Pass flag through to all C compiler invocations: "
+        "-Xswiftc[Pass flag through to all Swift compiler invocations]:Pass flag through to all Swift compiler invocations: "
+        "-Xlinker[Pass flag through to all linker invocations]:Pass flag through to all linker invocations: "
+        "-Xcxx[Pass flag through to all C++ compiler invocations]:Pass flag through to all C++ compiler invocations: "
+        "(--configuration -c)"{--configuration,-c}"[Build with configuration (debug|release) ]: :{_values '' 'debug[build with DEBUG configuration]' 'release[build with RELEASE configuration]'}"
+        "--build-path[Specify build/cache directory ]:Specify build/cache directory :_files"
+        "(--chdir -C)"{--chdir,-C}"[]: :_files"
+        "--package-path[Change working directory before any other operation]:Change working directory before any other operation:_files"
+        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]' 'undefined[enable Undefined Behavior sanitizer]'}"
+        "--disable-prefetching[]"
+        "--skip-update[Skip updating dependencies from their remote during a resolution]"
+        "--disable-sandbox[Disable using the sandbox when executing subprocesses]"
+        "--disable-package-manifest-caching[Disable caching Package.swift manifests]"
+        "--version[]"
+        "--destination[]: :_files"
+        "(--verbose -v)"{--verbose,-v}"[Increase verbosity of informational output]"
+        "--no-static-swift-stdlib[Do not link Swift stdlib statically \[default\]]"
+        "--static-swift-stdlib[Link Swift stdlib statically]"
+        "--force-resolved-versions[]"
+        "--disable-automatic-resolution[Disable automatic resolution if Package.resolved file is out-of-date]"
+        "--enable-index-store[Enable indexing-while-building feature]"
+        "--disable-index-store[Disable indexing-while-building feature]"
+        "--enable-pubgrub-resolver[\[Experimental\] Enable the new Pubgrub dependency resolver]"
+        "--enable-parseable-module-interfaces[]"
+        "--trace-resolver[]"
+        "(--jobs -j)"{--jobs,-j}"[The number of jobs to spawn in parallel during the build process]:The number of jobs to spawn in parallel during the build process: "
+        "--enable-test-discovery[Enable test discovery on platforms without Objective-C runtime]"
+        "--skip-build[Skip building the test target]"
+        "(--list-tests -l)"{--list-tests,-l}"[Lists test methods in specifier format]"
+        "--generate-linuxmain[Generate LinuxMain.swift entries for the package]"
+        "--parallel[Run the tests in parallel.]"
+        "--num-workers[Number of tests to execute in parallel.]:Number of tests to execute in parallel.: "
+        "(--specifier -s)"{--specifier,-s}"[]: : "
+        "--xunit-output[]: :_files"
+        "--filter[Run test cases matching regular expression, Format: <test-target>.<test-case> or <test-target>.<test-case>/<test>]:Run test cases matching regular expression, Format: <test-target>.<test-case> or <test-target>.<test-case>/<test>: "
+        "--enable-code-coverage[Test with code coverage enabled]"
+    )
+    _arguments $arguments && return
+}
+
+_swift_compiler() {
+}
+
+_swift


### PR DESCRIPTION
This had been generated with swift 5.1 binary `swift package completion-tool generate-zsh-script > _swift`

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [ ] This is a finished work.
- [ ] It has a header containing authors, status and origin of the script.
- [ ] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
