### PR TITLE
fall back to file completion for yarn scripts

### DIFF
--- a/src/_yarn
+++ b/src/_yarn
@@ -241,7 +241,7 @@ _yarn() {
         run)
           _arguments \
             '1: :_yarn_scripts' \
-            '*:: :_files'
+            '*:: :_default'
         ;;
 
         tag)
@@ -269,8 +269,7 @@ _yarn() {
         ;;
 
         *) 
-          _arguments \
-            '*:: :_files'
+          _default
         ;;
       esac
     ;;

--- a/src/_yarn
+++ b/src/_yarn
@@ -240,7 +240,8 @@ _yarn() {
 
         run)
           _arguments \
-            '1: :_yarn_scripts'
+            '1: :_yarn_scripts' \
+            '*:: :_files'
         ;;
 
         tag)
@@ -265,6 +266,11 @@ _yarn() {
         why)
           _arguments \
             '1:query:_files'
+        ;;
+
+        *) 
+          _arguments \
+            '*:: :_files'
         ;;
       esac
     ;;


### PR DESCRIPTION
We generally have a lot of scripts in our various `package.json` that we run via `yarn` (or `yarn run`) and these scripts' arguments are often local files; certainly as the "standard" form of shell completion it seems like the most reasonable fallback option to try when there is no longer anything that can be derived from the `yarn` context.