### PR TITLE
Added in missing jrnl option --edit

### DIFF
--- a/src/_jrnl
+++ b/src/_jrnl
@@ -59,6 +59,7 @@ _jrnl() {
       "-o[Optionally specifies output file when using --export If OUTPUT is a directory, exports each entry in individual file instead.]:output file:" \
       "--encrypt[Encrypts your existing journal with a new pass]" \
       "--decrypt[Decrypts your journal and stores it in plain text]" \
+      "--edit[Opens your editor to edit the selected entries.]" \
 }
 
 _jrnl


### PR DESCRIPTION
Just added in a missing option. Took text directly from output of the -h (help) command similar to the others in the file. Don't know if more is needed in the PR. 