### PR TITLE
YARN | Improve suggestions for `yarn run` command

### DIFF
--- a/src/_yarn
+++ b/src/_yarn
@@ -81,29 +81,21 @@ _yarn_commands_scripts() {
 }
 
 _yarn_scripts() {
-  local -a commands
-  local -a binaries
-  local -a scripts
-  local -a scriptsUnescaped
-  
-  binaries=($(yarn run --json 2>/dev/null | sed -E '/Commands available/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n' | sed -e 's/:/\\:/g'))
-  scriptsUnescaped=($(yarn run --json 2>/dev/null | sed -E '/possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n'))
-  scripts=($(echo "${scriptsUnescaped[@]}" | sed -e 's/:/\\:/g'))
-  scriptsObject=$(yarn run --json 2>/dev/null | sed -n '/.type.\s\?:\s\?.possibleCommands./p' | head -1)
+  local -a commands binaries scripts
+  local -a scriptNames scriptCommands
+  local i runJSON
 
-  if [ "$(command -v jq)" ]; then
-    for script in "${scriptsUnescaped[@]}"; do
-      scriptCommand=$(echo -E $scriptsObject | jq ".data.hints.\"$script\"")
-      commands+=("$(echo "${script//:/\\:}"):$scriptCommand")
-    done
-  else
-    for script in "${scripts[@]}"; do
-      commands+=("$script:package\.json")
-    done
-  fi
+  runJSON=$(yarn run --json 2>/dev/null)
+  binaries=($(sed -E '/Commands available/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g;s/:/\\:/g;s/,/\n/g' <<< "$runJSON"))
+  scriptNames=($(sed -E '/possibleCommands/!d;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g;s/:/\\:/g;s/,/\n/g' <<< "$runJSON"))
+  scriptCommands=("${(@f)$(sed -E '/possibleCommands/!d;s/.*"hints":\{([^}]+)\}.*/\1/;s/"[^"]+"://g;s/:/\\:/g;s/","/\n/g;s/(^"|"$)//g' <<< "$runJSON")}")
 
-  commands=("${commands[@]}" "${binaries[@]}")
-  _describe 'scripts' commands
+  for (( i=1; i <= $#scriptNames; i++ )); do
+    scripts+=("${scriptNames[$i]}:${scriptCommands[$i]}")
+  done
+
+  commands=($scripts $binaries)
+  _describe 'command' commands
 }
 
 _yarn_global_commands() {

--- a/src/_yarn
+++ b/src/_yarn
@@ -76,7 +76,7 @@ _global_commands=(
 
 _yarn_commands_scripts() {
   local -a scripts
-  scripts=($(yarn run --json 2>/dev/null | sed -E '/possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n' | sed -e 's/:/\\:/g'))
+  scripts=($(yarn run --json 2>/dev/null | sed -E '/Commands available|possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n' | sed -e 's/:/\\:/g'))
   _describe 'command or script' _commands -- _global_commands -- scripts
 }
 

--- a/src/_yarn
+++ b/src/_yarn
@@ -76,14 +76,34 @@ _global_commands=(
 
 _yarn_commands_scripts() {
   local -a scripts
-  scripts=($(yarn run --json 2>/dev/null | sed -E '/Commands available|possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n' | sed -e 's/:/\\:/g'))
+  scripts=($(yarn run --json 2>/dev/null | sed -E '/possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n' | sed -e 's/:/\\:/g'))
   _describe 'command or script' _commands -- _global_commands -- scripts
 }
 
 _yarn_scripts() {
+  local -a commands
+  local -a binaries
   local -a scripts
-  scripts=($(yarn run --json 2>/dev/null | sed -E '/Commands available|possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n' | sed -e 's/:/\\:/g'))
-  _describe 'script' scripts
+  local -a scriptsUnescaped
+  
+  binaries=($(yarn run --json 2>/dev/null | sed -E '/Commands available/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n' | sed -e 's/:/\\:/g'))
+  scriptsUnescaped=($(yarn run --json 2>/dev/null | sed -E '/possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n'))
+  scripts=($(echo "${scriptsUnescaped[@]}" | sed -e 's/:/\\:/g'))
+  scriptsObject=$(yarn run --json 2>/dev/null | sed -n '/.type.\s\?:\s\?.possibleCommands./p' | head -1)
+
+  if [ "$(command -v jq)" ]; then
+    for script in "${scriptsUnescaped[@]}"; do
+      scriptCommand=$(echo -E $scriptsObject | jq ".data.hints.\"$script\"")
+      commands+=("$(echo "${script//:/\\:}"):$scriptCommand")
+    done
+  else
+    for script in "${scripts[@]}"; do
+      commands+=("$script:package\.json")
+    done
+  fi
+
+  commands=("${commands[@]}" "${binaries[@]}")
+  _describe 'scripts' commands
 }
 
 _yarn_global_commands() {


### PR DESCRIPTION
#### New Behavior

> Separate scripts between `package.json` and `node_modules/.bin/`.

![zsh-completions-yarn new behavior](https://user-images.githubusercontent.com/10104630/66055272-22de8780-e4ea-11e9-894c-f533cbd6a3cd.png)

#### Old Behavior

> Package scripts and binaries mixed together

![oh-my-zsh-yarn-old-behavior](https://user-images.githubusercontent.com/10104630/63997486-81f84900-cab3-11e9-8d2d-193d4655b32b.png)

#### Extra

Following [this feedback](https://github.com/robbyrussell/oh-my-zsh/pull/8118#issuecomment-537148142), binaries will always be suggested.

This commit fixes robbyrussell/oh-my-zsh#8115

This commit fixes robbyrussell/oh-my-zsh#8118
