### PR TITLE
Yarn | cross-platform sed replacement pattern newline solution

### DIFF
--- a/src/_yarn
+++ b/src/_yarn
@@ -86,9 +86,11 @@ _yarn_scripts() {
   local i runJSON
 
   runJSON=$(yarn run --json 2>/dev/null)
-  binaries=($(sed -E '/Commands available/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g;s/:/\\:/g;s/,/\n/g' <<< "$runJSON"))
-  scriptNames=($(sed -E '/possibleCommands/!d;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g;s/:/\\:/g;s/,/\n/g' <<< "$runJSON"))
-  scriptCommands=("${(@f)$(sed -E '/possibleCommands/!d;s/.*"hints":\{(.+")\}.*/\1/;s/"[^"]+"://g;s/:/\\:/g;s/","/\n/g;s/(^"|"$)//g' <<< "$runJSON")}")
+  # Some sed utilities (e.g. Mac OS / BSD) don't interpret `\n` in a replacement
+  # pattern as a newline. See https://superuser.com/q/307165
+  binaries=($(sed -E '/Commands available/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g;s/:/\\:/g;s/,/\'$'\n/g' <<< "$runJSON"))
+  scriptNames=($(sed -E '/possibleCommands/!d;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g;s/:/\\:/g;s/,/\'$'\n/g' <<< "$runJSON"))
+  scriptCommands=("${(@f)$(sed -E '/possibleCommands/!d;s/.*"hints":\{(.+")\}.*/\1/;s/"[^"]+"://g;s/:/\\:/g;s/","/\'$'\n/g;s/(^"|"$)//g' <<< "$runJSON")}")
 
   for (( i=1; i <= $#scriptNames; i++ )); do
     scripts+=("${scriptNames[$i]}:${scriptCommands[$i]}")


### PR DESCRIPTION
Some sed utilities (e.g. Mac OS / BSD) don't interpret `\n` in a replacement pattern as a newline. See the discussion [here](https://www.superuser.com/q/307165).

Solution tested at https://github.com/MaximDevoir/zsh-completions-662/runs/286153577 on Mac and Ubuntu

Fixes #662 