### PR TITLE
_yarn: fix parsing of yarn run on scripts containing }

### DIFF
--- a/src/_yarn
+++ b/src/_yarn
@@ -88,7 +88,7 @@ _yarn_scripts() {
   runJSON=$(yarn run --json 2>/dev/null)
   binaries=($(sed -E '/Commands available/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g;s/:/\\:/g;s/,/\n/g' <<< "$runJSON"))
   scriptNames=($(sed -E '/possibleCommands/!d;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g;s/:/\\:/g;s/,/\n/g' <<< "$runJSON"))
-  scriptCommands=("${(@f)$(sed -E '/possibleCommands/!d;s/.*"hints":\{([^}]+)\}.*/\1/;s/"[^"]+"://g;s/:/\\:/g;s/","/\n/g;s/(^"|"$)//g' <<< "$runJSON")}")
+  scriptCommands=("${(@f)$(sed -E '/possibleCommands/!d;s/.*"hints":\{(.+")\}.*/\1/;s/"[^"]+"://g;s/:/\\:/g;s/","/\n/g;s/(^"|"$)//g' <<< "$runJSON")}")
 
   for (( i=1; i <= $#scriptNames; i++ )); do
     scripts+=("${scriptNames[$i]}:${scriptCommands[$i]}")


### PR DESCRIPTION
When a package.json script command uses the closing curly brace, the current `yarn run` parsing fails to capture the whole hints property value, leading to it not parsing correctly the rest of the scripts commands. See #667.

This solution uses the fact that the hints property value always ends with a double quote and a closing curly brace to match the whole property value, disregarding whether a closing curly brace is used in a script command. See https://github.com/zsh-users/zsh-completions/issues/667#issuecomment-549130152.

Fixes #667 

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
