### PR TITLE
[cmake] updates for cmake 3.16

### DIFF
--- a/src/_cmake
+++ b/src/_cmake
@@ -328,6 +328,7 @@ _cmake_define_common_property_names() {
     'CMAKE_EXPORT_COMPILE_COMMANDS:Enable/disable output of compilation database during generation'
     'CMAKE_RULE_MESSAGES:Specify whether to report a message for each make rule'
     'CMAKE_VERBOSE_MAKEFILE:Enable verbose output from Makefile builds'
+    'CMAKE_UNITY_BUILD:Batch include source files'
   )
 
   _describe -t 'common-property-names' 'common property name' properties $@
@@ -348,6 +349,7 @@ _cmake_define_property_values() {
     (CMAKE_COLOR_MAKEFILE) _wanted booleans expl 'boolean' _cmake_booleans && ret=0;;
     (CMAKE_RULE_MESSAGES)  _wanted booleans expl 'boolean' _cmake_booleans && ret=0;;
     (CMAKE_VERBOSE_MAKEFILE) _wanted booleans expl 'boolean' _cmake_booleans && ret=0;;
+    (CMAKE_UNITY_BUILD) _wanted booleans expl 'boolean' _cmake_booleans && ret=0;;
     (CMAKE_INSTALL_PREFIX) _files -/ && ret=0;;
     (CMAKE_EXPORT_COMPILE_COMMANDS) _wanted booleans expl 'boolean' _cmake_booleans && ret=0;;
     (CMAKE_*_COMPILER)     _wanted compilers expl 'compiler' _cmake_compilers && ret=0;;

--- a/src/_cmake
+++ b/src/_cmake
@@ -72,6 +72,8 @@ local cmake_build_options;cmake_build_options=(
     '-i[Run in wizard mode]'
     '-L-[List cache variables]::_values "options" "[non-advanced cache variables]" "A[advanced cache variables]" "H[non-advanced cached variables with help]" "AH[advanced cache variables with help]"'
     '--trace[Put cmake in trace mode]'
+    '--trace-redirect=[redirect trace output to file]:trace file:_files'
+    '--log-level=[only print messages at or above the specified log level]:loglevel:(ERROR WARNING NOTICE STATUS VERBOSE DEBUG TRACE)'
     '--find-package[Run in pkg-config like mode.]'
     ':cmake project:_files -/'
 )


### PR DESCRIPTION
This follows up on the changes in [cmake 3.16](https://cmake.org/cmake/help/v3.16/release/3.16.html). Of what seemed to be relevant to the commandline in the release notes, I skipped `CMAKE_CUDA_RESOLVE_DEVICE_SYMBOLS` and `CMAKE_ECLIPSE_RESOURCE_ENCODING` as I am not confident about how they are intended how to be used / what the possible useful values would be.
