### PR TITLE
Add file completion to `mix format`

### DIFF
--- a/src/_mix
+++ b/src/_mix
@@ -163,6 +163,7 @@ __task_list ()
         'escript.uninstall'
         'gettext.extract'
         'gettext.merge'
+        'format'
         'help'
         'hex'
         'hex.build'
@@ -227,6 +228,10 @@ case $state in
          return
       ;;
       (test)
+         _arguments ':PATH:_files'
+         return
+      ;;
+      (format)
          _arguments ':PATH:_files'
          return
       ;;


### PR DESCRIPTION
When I type `mix format` and press tab, it says "no matches found". It's fixed in this little PR