### PR TITLE
Add more options for Android emulator completion

### DIFF
--- a/src/_emulator
+++ b/src/_emulator
@@ -39,9 +39,11 @@ _arguments \
   '(- : *)-help-sdk-images[about disk images when using the SDK]' \
   '(- : *)-help-build-images[about disk images when building Android]' \
   '(- : *)-help-all[prints all help content]' \
-  '(- : *)-help-'{version,sysdir,system,image,datadir,kernel,ramdisk,initdata,data,partition-size,cache,no-cache,nocache,sdcard,snapstorage,no-snapstorage,snapshot,no-snapshot,no-snapshot-save,no-snapshot-load,snapshot-list,no-snapshot-update-time,wipe-data,avd,skindir,skin,noskin,no-skin,memory,netspeed,netdelay,netfast,trace,show-kernel,shell,no-jni,nojni,logcat,noaudio,no-audio,audio,raw-keys,radio,port,ports,onion,onion-alpha,onion-rotation,scale,dpi-device,http-proxy,timezone,dns-server,cpu-delay,no-boot-anim,no-window,report-console,gps,keyset,shell-serial,tcpdump,bootchart,charmap,prop,shared-net-id,nand-limits,memcheck,qemu,verbose}'[print option-specific help]' \
+  '(- : *)-help-'{version,list-avds,sysdir,system,writable-system,image,datadir,kernel,ramdisk,initdata,data,partition-size,cache,no-cache,nocache,sdcard,snapstorage,no-snapstorage,snapshot,no-snapshot,no-snapshot-save,no-snapshot-load,snapshot-list,no-snapshot-update-time,wipe-data,avd,skindir,skin,noskin,no-skin,memory,cores,accel,no-accel,netspeed,netdelay,netfast,trace,show-kernel,shell,no-jni,nojni,logcat,noaudio,no-audio,audio,raw-keys,radio,port,ports,onion,onion-alpha,onion-rotation,scale,dpi-device,http-proxy,timezone,dns-server,cpu-delay,no-boot-anim,no-window,report-console,gps,keyset,shell-serial,tcpdump,bootchart,charmap,prop,shared-net-id,nand-limits,memcheck,qemu,verbose}'[print option-specific help]' \
+  '-list-avds[list available AVDs]' \
   '-sysdir[search for system disk images in the directory]: :_files -/' \
   '(-system -image)'{-system,-image}'[read initial system image from the file]: :_files -g "*.img"' \
+  '-writable-system[make system image writable after '\''adb remount'\'']' \
   '-datadir[write user data into the directory]: :_files -/' \
   '-kernel[use specific emulated kernel]: :_files' \
   '-ramdisk[ramdisk image (default <system>/ramdisk.img]: :_files -g "*.img"' \
@@ -65,6 +67,9 @@ _arguments \
   '-skin[select a given skin]' \
   '(-noskin -no-skin)'{-noskin,-no-skin}'[don'\''t use any emulator skin]' \
   '-memory[physical RAM size in MBs]:size (in MBs)' \
+  '-cores[Set number of CPU cores to emulator]:number' \
+  '(-no-accel)-accel[Configure emulation acceleration]:mode' \
+  '(-accel)-no-accel[Same as '\''-accel off'\'']' \
   '-netspeed[maximum network download/upload speeds]:speed' \
   '-netdelay[network latency emulation]:delay' \
   '-netfast[disable network shaping]' \


### PR DESCRIPTION
This adds several options to _emulator:

* -list-avds
* -writable-system
* -cores
* -accel
* -no-accel
* -help entries for each of the above

Issue #41
Test: loaded this plugin and tested tab completion on these options,
messages seem fine

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
