### PR TITLE
Complete only .log file if --prof-process is specified

### DIFF
--- a/src/_node
+++ b/src/_node
@@ -37,10 +37,18 @@
 #  * Mario Fernandez (https://github.com/sirech)
 #  * Nicholas Penree (https://github.com/drudge)
 #  * Masafumi Koba (https://github.com/ybiquitous)
+#  * Shohei YOSHIDA (https://github.com/syohex)
 #
 # ------------------------------------------------------------------------------
 
 _node_files() {
+  for (( i = 2; i < CURRENT; i++)); do
+    if [[ ${words[i]} == "--prof-process" ]]; then
+      _files -g "*.log"
+      return
+    fi
+  done
+
   _files -g "*.(js|mjs)"
 }
 


### PR DESCRIPTION
Fixes: https://github.com/zsh-users/zsh-completions/issues/633

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
