### PR TITLE
kitchen: fix regexp which collects subcommands

### DIFF
--- a/src/_kitchen
+++ b/src/_kitchen
@@ -35,6 +35,7 @@
 # -------
 #
 #  * Peter Eisentraut (https://github.com/petere)
+#  * Shohei YOSHIDA (https://github.com/syohex)
 #
 # ------------------------------------------------------------------------------
 
@@ -67,7 +68,7 @@ _kitchen() {
 _kitchen_commands() {
   local commands
 
-  commands=("${(@f)$(_call_program commands $service help | sed -n 's/^  kitchen \([[:alpha:]]*\) [ [].*# \(.*\)$/\1:\2/p')}")
+  commands=("${(@f)$(_call_program commands $service help | sed -n 's/^  kitchen \([[:alpha:]]*\) .*# \(.*\)$/\1:\2/p')}")
   _describe -t commands 'kitchen commands' commands
 }
 


### PR DESCRIPTION
fix: https://github.com/zsh-users/zsh-completions/issues/677

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.

#### screenshot

##### before

![before](https://user-images.githubusercontent.com/554281/77341038-79c66a80-6d71-11ea-94c3-b83b4f575993.png)

##### apply this patch

![after](https://user-images.githubusercontent.com/554281/77341035-78953d80-6d71-11ea-9727-26a7c35b50cf.png)

