### PR TITLE
Don't use _git private functions

### DIFF
--- a/src/_git-wtf
+++ b/src/_git-wtf
@@ -36,8 +36,15 @@
 # -------
 #
 #  * Mario Fernandez (https://github.com/sirech)
+#  * Shohei YOSHIDA (https://github.com/syohex)
 #
 # ------------------------------------------------------------------------------
+
+__git_wtf_branches() {
+  local -a branches
+  branches=(${(f)"$(git for-each-ref --format='%(refname:short)' refs/heads/)"})
+  _describe 'branch' branches
+}
 
 _arguments -w -C -s \
     '(--long --short)'{-l,--long}'[include author info and date for each commit]' \
@@ -47,7 +54,7 @@ _arguments -w -C -s \
     '(--key)'{-k,--key}'[show key]' \
     '(--relations)'{-r,--relations}'[show relation to features / integration branches]' \
     '(--dump-config)--dump-config[print out current configuration and exit]' \
-    '*: :__git_branch_names'
+    '*: :__git_wtf_branches'
 
 # Local Variables:
 # mode: Shell-Script


### PR DESCRIPTION
Use own function instead.

This fixes #99 issue. `_git-wtf` uses `__git_branch_names` function which is a private function and defined in `_git`. Private function cannot be auto-loaded. So define own function and use it instead.

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
