### PR TITLE
Improve node inspect completion

### DIFF
--- a/src/_node
+++ b/src/_node
@@ -52,6 +52,15 @@ _node_files() {
   _files -g "*.(js|mjs)"
 }
 
+_node_args() {
+  if (( CURRENT == 2 )); then
+    _alternative "_node_files" "_values 'command' 'inspect[enable inspector for debugging]'"
+    return
+  fi
+
+  _node_files
+}
+
 local curcontext="$curcontext" state line ret=1
 typeset -A opt_args
 
@@ -150,10 +159,7 @@ _arguments -C \
   '(- 1 *)'{-p,--print}'[evaluate script and print result]:inline JavaScript' \
   '*'{-r,--require}'[module to preload (option can be repeated)]: :_node_files' \
   '(- 1 *)'{-v,--version}'[print Node.js version]' \
-  '*: :_node_files' && ret=0
-
-_values 'commands' \
-  'inspect[enable inspector for debugging]' && ret=0
+  '*: :_node_args' && ret=0
 
 return ret
 


### PR DESCRIPTION
It should be completed only after 'node'

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.

Fix annoying `inspect` completions

![before](https://user-images.githubusercontent.com/554281/80100348-d0aaa400-85aa-11ea-965f-57ab5edc2d3c.gif)

Original version
- `inspect` can be completed multiple times
- `inspect` appears also option value completion such as `--use-largepages`

![after](https://user-images.githubusercontent.com/554281/80100489-fc2d8e80-85aa-11ea-96bf-36490b224843.gif)

This PR version
- `inspect` is completed only after `node`
- `inspect` is completed only once
- `inspect` does not appear at completing option values
