### PR TITLE
Update stack completions as in the current version 2.3.0.1 

### DIFF
--- a/src/_stack
+++ b/src/_stack
@@ -45,8 +45,10 @@ _stack () {
         --version'[show version]' \
         --numeric-version'[show only version number]' \
         --hpack-numeric-version"[show only hpack's version number]" \
-        '--docker*[run "stack --docker-help" for details]' \
-        '--nix*[run "stack --nix-help" for details]' \
+        '--docker[enable using a Docker container, run "stack --docker-help" for details]' \
+        '--no-docker[disable using a Docker container, run "stack --docker-help" for details]' \
+        '--nix[enable use of a Nix-shell, run "stack --nix-help" for details]' \
+        '--no-nix[disable use of a Nix-shell, run "stack --nix-help" for details]' \
         --verbosity'[verbosity: silent, error, warn, info, debug]' \
         {-v,--verbose}'[enable verbose mode: verbosity level "debug"]' \
         --silent'[enable silent mode: verbosity level "silent"]' \

--- a/src/_stack
+++ b/src/_stack
@@ -26,41 +26,66 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ------------------------------------------------------------------------------
 # Description
-# -----------
+# ------------------------------------------------------------------------------
 #
-#  Completion script for stack (https://github.com/commercialhaskell/stack).
+# Completion script for stack (https://github.com/commercialhaskell/stack).
 #
 # ------------------------------------------------------------------------------
 # Authors
-# -------
+# ------------------------------------------------------------------------------
 #
-#  * Toshiki Teramura <toshiki.teramura@gmail.com>
+# * Toshiki Teramura <toshiki.teramura@gmail.com>
+# * Nikita Ursol <nikita20001116@gmail.com>
 #
 # ------------------------------------------------------------------------------
 
 _stack () {
     _arguments \
-        --version'[display version information]' \
-        --help'[display usage information]' \
-        '--docker*''[run "stack --docker-help" for details]' \
+        --help'[show usage information]' \
+        --version'[show version]' \
+        --numeric-version'[show only version number]' \
+        --hpack-numeric-version"[Show only hpack's version number]" \
+        '--docker*[run "stack --docker-help" for details]' \
+        '--nix*[run "stack --nix-help" for details]' \
         --verbosity'[verbosity: silent, error, warn, info, debug]' \
         {-v,--verbose}'[enable verbose mode: verbosity level "debug"]' \
-        --system-ghc'[enable using the system installed GHC (on the PATH) if available and a matching version]' \
-        --no-system-ghc'[disable using the system installed GHC (on the PATH) if available and a matching version]' \
-        --install-ghc'[enable downloading and installing GHC if necessary (can be done manually with stack setup)]' \
-        --no-install-ghc'[disable downloading and installing GHC if necessary (can be done manually with stack setup)]' \
+        --silent'[enable silent mode: verbosity level "silent"]' \
+        --time-in-log'[enable inclusion of timings in logs, to use diff with logs]' \
+        --no-time-in-log'[disable inclusion of timings in logs, to use diff with logs]' \
+        --stack-root'[absolute path to the global stack root directory]' \
+        --work-dir'[relative path of work directory]' \
+        --system-ghc'[enable using the system installed GHC if available and a matching version]' \
+        --no-system-ghc'[disable using the system installed GHC if available and a matching version]' \
+        --install-ghc'[enable downloading and installing GHC if necessary]' \
+        --no-install-ghc'[disable downloading and installing GHC if necessary]' \
         --arch'[system architecture, e.g. i386, x86_64]' \
-        --os'[operating system, e.g. linux, windows]' \
+        --ghc-variant'[specialized GHC variant, e.g. integersimple (incompatible with --system-ghc)]' \
+        --ghc-build'[specialized GHC build, e.g. "gmp4" or "standard" (usually auto-detected)]' \
         {-j,--jobs}'[number of concurrent jobs to run]' \
         --extra-include-dirs'[extra directories to check for C header files]' \
         --extra-lib-dirs'[extra directories to check for libraries]' \
+        --with-gcc'[use custom path to gcc executable]' \
+        --with-hpack'[use custom path to hpack executable]' \
         --skip-ghc-check'[enable skipping the GHC version and architecture check]' \
         --no-skip-ghc-check'[disable skipping the GHC version and architecture check]' \
         --skip-msys'[enable skipping the local MSYS installation (Windows only)]' \
         --no-skip-msys'[disable skipping the local MSYS installation (Windows only)]' \
+        --local-bin-path'[install binaries to DIR]' \
+        --setup-info-yaml'[alternate URL or relative / absolute path for stack dependencies]' \
+        --modify-code-page'[enable setting the codepage to support UTF-8 (Windows only)]' \
+        --no-modify-code-page'[disable setting the codepage to support UTF-8 (Windows only)]' \
+        --allow-different-user'[enable permission for non-owners to use a stack installation (POSIX only)]' \
+        --no-allow-different-user'[disable permission for non-owners to use a stack installation (POSIX only)]' \
+        --dump-logs'[enable dump the build output logs for local packages to the console]' \
+        --no-dump-logs'[disable dump the build output logs for local packages to the console]' \
+        {--color,--colour}'[Specify when to use color in output; WHEN is "always", "never", or "auto".]' \
         --resolver'[override resolver in project file]' \
-        --no-terminal'[override terminal detection in the case of running in a false terminal]' \
-        --stack-yaml'[override project stack.yaml file (overrides any STACK_YAML environment variable)]' \
+        --terminal'[enable overriding terminal detection in the case of running in a false terminal]' \
+        --no-terminal'[disable overriding terminal detection in the case of running in a false terminal]' \
+        {--stack-colors,--stack-colours}"[Specify stack's output styles]" \
+        --terminal-width'[Specify the width of the terminal, used for pretty-print messages]' \
+        --stack-yaml'[override project stack.yaml file]' \
+        --lock-file'[Specify how to interact with lock files.]' \
         '*: :__stack_modes'
 }
 
@@ -73,22 +98,34 @@ __stack_modes () {
         'bench[build and benchmark the project(s) in this directory/configuration]' \
         'haddock[generate haddocks for the project(s) in this directory/configuration]' \
         'new[create a brand new project]' \
-        'init[initialize a stack project based on one or more cabal packages]' \
-        'solver[use a dependency solver to try and determine missing extra-deps]' \
+        'templates[show how to find templates available for "stack new".]' \
+        'init[create stack project config from cabal or hpack package specifications]' \
         'setup[get the appropriate ghc for your project]' \
         'path[print out handy path information]' \
+        "ls[list command. (Supports snapshots, dependencies and stack's styles)]" \
         'unpack[unpack one or more packages locally]' \
         'update[update the package index]' \
-        'upgrade[upgrade to the latest stack (experimental)]' \
+        'upgrade[upgrade to the latest stack]' \
         'upload[upload a package to Hackage]' \
+        'sdist[create source distribution tarballs]' \
         'dot[visualize your projects dependency graph using Graphviz dot]' \
-        'exec[execute a command]' \
         'ghc[run ghc]' \
-        'ghci[run ghci in the context of project(s)]' \
-        'ide[run ide-backend-client with the correct arguments]' \
+        'hoogle[run hoogle, the Haskell API search engine.]' \
+        'exec[execute a command]' \
+        'run[build and run an executable.]' \
+        'ghci[run ghci in the context of package(s) (experimental)]' \
+        "repl[run ghci in the context of package(s) (experimental) (alias for 'ghci')]" \
         'runghc[run runghc]' \
-        'clean[clean the local packages]' \
-        'docker[subcommands specific to Docker use]'
+        "runhaskell[run runghc (alias for 'runghc')]" \
+        'script[run a Stack Script]' \
+        'eval[evaluate some haskell code inline.]' \
+        'clean[delete build artefacts for the project packages.]' \
+        'purge[delete the project stack working directories.]' \
+        'query[Query general build information (experimental)]' \
+        'ide[IDE-specific commands]' \
+        'docker[subcommands specific to Docker use]' \
+        'config[Subcommands for accessing and modifying configuration values]' \
+        'hpc[Subcommands specific to Haskell Program Coverage]'
 
 }
 

--- a/src/_stack
+++ b/src/_stack
@@ -44,7 +44,7 @@ _stack () {
         --help'[show usage information]' \
         --version'[show version]' \
         --numeric-version'[show only version number]' \
-        --hpack-numeric-version"[Show only hpack's version number]" \
+        --hpack-numeric-version"[show only hpack's version number]" \
         '--docker*[run "stack --docker-help" for details]' \
         '--nix*[run "stack --nix-help" for details]' \
         --verbosity'[verbosity: silent, error, warn, info, debug]' \
@@ -70,7 +70,7 @@ _stack () {
         --no-skip-ghc-check'[disable skipping the GHC version and architecture check]' \
         --skip-msys'[enable skipping the local MSYS installation (Windows only)]' \
         --no-skip-msys'[disable skipping the local MSYS installation (Windows only)]' \
-        --local-bin-path'[install binaries to DIR]' \
+        --local-bin-path'[install binaries to specified location]' \
         --setup-info-yaml'[alternate URL or relative / absolute path for stack dependencies]' \
         --modify-code-page'[enable setting the codepage to support UTF-8 (Windows only)]' \
         --no-modify-code-page'[disable setting the codepage to support UTF-8 (Windows only)]' \
@@ -78,7 +78,7 @@ _stack () {
         --no-allow-different-user'[disable permission for non-owners to use a stack installation (POSIX only)]' \
         --dump-logs'[enable dump the build output logs for local packages to the console]' \
         --no-dump-logs'[disable dump the build output logs for local packages to the console]' \
-        {--color,--colour}'[specify when to use color in output; WHEN is "always", "never", or "auto".]' \
+        {--color,--colour}'[specify when to use color in output; accepts "always", "never", "auto"]' \
         --resolver'[override resolver in project file]' \
         --terminal'[enable overriding terminal detection in the case of running in a false terminal]' \
         --no-terminal'[disable overriding terminal detection in the case of running in a false terminal]' \
@@ -102,7 +102,7 @@ __stack_modes () {
         'init[create stack project config from cabal or hpack package specifications]' \
         'setup[get the appropriate ghc for your project]' \
         'path[print out handy path information]' \
-        "ls[list command. (Supports snapshots, dependencies and stack's styles)]" \
+        "ls[list command. (supports snapshots, dependencies and stack's styles)]" \
         'unpack[unpack one or more packages locally]' \
         'update[update the package index]' \
         'upgrade[upgrade to the latest stack]' \

--- a/src/_stack
+++ b/src/_stack
@@ -78,14 +78,14 @@ _stack () {
         --no-allow-different-user'[disable permission for non-owners to use a stack installation (POSIX only)]' \
         --dump-logs'[enable dump the build output logs for local packages to the console]' \
         --no-dump-logs'[disable dump the build output logs for local packages to the console]' \
-        {--color,--colour}'[Specify when to use color in output; WHEN is "always", "never", or "auto".]' \
+        {--color,--colour}'[specify when to use color in output; WHEN is "always", "never", or "auto".]' \
         --resolver'[override resolver in project file]' \
         --terminal'[enable overriding terminal detection in the case of running in a false terminal]' \
         --no-terminal'[disable overriding terminal detection in the case of running in a false terminal]' \
-        {--stack-colors,--stack-colours}"[Specify stack's output styles]" \
-        --terminal-width'[Specify the width of the terminal, used for pretty-print messages]' \
+        {--stack-colors,--stack-colours}"[specify stack's output styles]" \
+        --terminal-width'[specify the width of the terminal, used for pretty-print messages]' \
         --stack-yaml'[override project stack.yaml file]' \
-        --lock-file'[Specify how to interact with lock files.]' \
+        --lock-file'[specify how to interact with lock files.]' \
         '*: :__stack_modes'
 }
 
@@ -121,11 +121,11 @@ __stack_modes () {
         'eval[evaluate some haskell code inline.]' \
         'clean[delete build artefacts for the project packages.]' \
         'purge[delete the project stack working directories.]' \
-        'query[Query general build information (experimental)]' \
-        'ide[IDE-specific commands]' \
+        'query[query general build information (experimental)]' \
+        'ide[ide-specific commands]' \
         'docker[subcommands specific to Docker use]' \
-        'config[Subcommands for accessing and modifying configuration values]' \
-        'hpc[Subcommands specific to Haskell Program Coverage]'
+        'config[subcommands for accessing and modifying configuration values]' \
+        'hpc[subcommands specific to Haskell Program Coverage]'
 
 }
 


### PR DESCRIPTION
Stack actually provides [script for completions](https://docs.haskellstack.org/en/stable/shell_autocompletion/#shell-auto-completion), but it doesn't distinguish between 'no-' and standalone options, doesn't provide descriptions.

This PR was based on the output of `stack --info`, descriptions were slightly modified to decrease length.