### PR TITLE
Fix run subcommand --cwd issue

### DIFF
--- a/src/_yarn
+++ b/src/_yarn
@@ -36,6 +36,8 @@
 #
 # ------------------------------------------------------------------------------
 
+declare -g _yarn_run_cwd
+
 _commands=(
   'access'
   'audit:Checks for known security issues with the installed packages'
@@ -99,8 +101,8 @@ _yarn_scripts() {
   local -a scriptNames scriptCommands
   local i runJSON
 
-  if [[ -n $opt_args[--cwd] ]]; then
-    runJSON=$(cd $opt_args[--cwd] && yarn run --json 2>/dev/null)
+  if [[ -n $_yarn_run_cwd ]]; then
+    runJSON=$(cd $_yarn_run_cwd && yarn run --json 2>/dev/null)
   else
     runJSON=$(yarn run --json 2>/dev/null)
   fi
@@ -313,6 +315,11 @@ _yarn() {
         ;;
 
         run)
+          if [[ -n $opt_args[--cwd] ]]; then
+            _yarn_run_cwd=$opt_args[--cwd]
+          else
+            _yarn_run_cwd=''
+          fi
           _arguments \
             '1: :_yarn_scripts' \
             '*:: :_default'


### PR DESCRIPTION
opt_args cannot be read from 2nd completion

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.

#713 has issue with `--cwd` passed.
