### PR TITLE
Don't use sed gnu extension, use POSIX syntax

### DIFF
--- a/src/_yarn
+++ b/src/_yarn
@@ -137,7 +137,7 @@ _yarn_add_files() {
 }
 
 _yarn_workspaces() {
-  local -a workspaces=(${(@f)$(yarn workspaces info |sed -n -r -e 's/^  "([^"]+)": \{/\1/p')})
+  local -a workspaces=(${(@f)$(yarn workspaces info |sed -n -e 's/^  "\([^"]*\)": {/\1/p')})
   _describe 'workspace' workspaces
 }
 


### PR DESCRIPTION
<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.

#713 workspace completion works only with GNU sed. This PR fix it and use POSIX sed features
