### PR TITLE
pgsql: Check for pg_config existence

### DIFF
--- a/src/_pgsql_utils
+++ b/src/_pgsql_utils
@@ -147,10 +147,9 @@ _pgsql_databases () {
     _pgsql_get_identity
 
     local _pgsql_services _pgsql_service_files
-    _pgsql_service_files=(
-      ~/.pg_service.conf
-      $(pg_config --sysconfdir)/pg_service.conf
-    )
+    _pgsql_service_files=(~/.pg_service.conf)
+    (( $+commands[pg_config] )) && _pgsql_service_files+=$(pg_config --sysconfdir)/pg_service.conf
+
     _pgsql_services=$( grep -h '^\[.*\]' $_pgsql_service_files 2>/dev/null \
                          | sed -e 's/^\[/service=/' -e 's/\].*$//' )
 


### PR DESCRIPTION
pg_config isn't installed by default on many systems, and is usually
part of postgresql-libs-devel or some such, leading to needless
"pg_config not found" errors on completion.