### PR TITLE
pgsql: add -X to psql commands to prevent loading ~/.psqlrc

### DIFF
--- a/src/_pgsql_utils
+++ b/src/_pgsql_utils
@@ -89,7 +89,7 @@ _pgsql_users () {
 
     _pgsql_user_sql='select r.rolname from pg_catalog.pg_roles r where r.rolcanlogin = true'
 
-    compadd "$@" - $( psql $_pgsql_params[@] -Aqt -c $_pgsql_user_sql template1 2>/dev/null )
+    compadd "$@" - $( psql $_pgsql_params[@] -XAqt -c $_pgsql_user_sql template1 2>/dev/null )
 
 }
 
@@ -122,7 +122,7 @@ _pgsql_tables () {
 	order by 1"
 
     compadd "$@" - \
-        $( psql $_pgsql_params[@] -Aqt -c $_pgsql_table_sql $db 2>/dev/null )
+        $( psql $_pgsql_params[@] -AXqt -c $_pgsql_table_sql $db 2>/dev/null )
 }
 
 _pgsql_schemas () {
@@ -139,7 +139,7 @@ _pgsql_schemas () {
         order by 1;"
 
     compadd "$@" - \
-        $( psql $_pgsql_params[@] -Aqt -c $_pgsql_schema_sql $db 2>/dev/null )
+        $( psql $_pgsql_params[@] -AXqt -c $_pgsql_schema_sql $db 2>/dev/null )
 }
 
 _pgsql_databases () {
@@ -160,7 +160,7 @@ _pgsql_databases () {
 
     compadd "$@" - \
             ${(f)_pgsql_services} \
-            $( psql $_pgsql_params[@] -Atq -c $_pgsql_db_sql template1 2>/dev/null )
+            $( psql $_pgsql_params[@] -AXtq -c $_pgsql_db_sql template1 2>/dev/null )
 }
 
 _pgsql_encodings () {
@@ -170,7 +170,7 @@ _pgsql_encodings () {
     local _pgsql_db_sql
     _pgsql_db_sql="select pg_encoding_to_char(i) from generate_series(0,100) i;"
 
-    compadd "$@" - $( psql $_pgsql_params[@] -Atq -c $_pgsql_db_sql template1  )
+    compadd "$@" - $( psql $_pgsql_params[@] -AXtq -c $_pgsql_db_sql template1  )
 }
 
 


### PR DESCRIPTION
The ~/.psqlrc may alter the output. In particular, I have '\timing on'
in there to add timings. This is useful when using psql, but not when
relying on it in scripts.

For example:

    psql -Aqt -c "select n.nspname \
        from pg_catalog.pg_namespace n \
        where n.nspname "'!~'" '^pg_' \
          and n.nspname <> 'information_schema' \
        order by 1;" postgres 2>/dev/null

Gives the output:

    public
    Time: 1.882 ms

Whereas with -X it gives the standard output:

    public