### PR TITLE
go: add zstyle to prevent listing packages from GOROOT and GOPATH

### DIFF
--- a/src/_golang
+++ b/src/_golang
@@ -43,6 +43,18 @@
 #  * Go authors
 #
 # ------------------------------------------------------------------------------
+# Notes
+# -----
+#
+#   * To disable listing packages from GOROOT (i.e. Go stdlib) in completions use:
+#
+#       zstyle ':completion:*:go:*' no-goroot true
+#
+#   * To disable listing packages from GOPATH in completions use:
+#
+#       zstyle ':completion:*:go:*' no-gopath true
+#
+# ------------------------------------------------------------------------------
 
 __go_buildmodes() {
   local -a buildmodes
@@ -358,11 +370,16 @@ case $state in
     __go_packages() {
       local gopaths
       declare -a gopaths
-      gopaths=("${(s/:/)$(go env GOPATH)}")
-      gopaths+=("$(go env GOROOT)")
+      if ! zstyle -t ":completion:${curcontext}:" no-gopath; then
+        gopaths=("${(s/:/)$(go env GOPATH)}")
+      fi
+      if ! zstyle -t ":completion:${curcontext}:" no-goroot; then
+        gopaths+=("$(go env GOROOT)")
+      fi
       for p in $gopaths; do
         _path_files $@ -W "$p/src" -/
       done
+
       # no special treatment for
       # - relative paths starting with ..
       # - absolute path starting with /


### PR DESCRIPTION
Adding all of GOROOT means all of stdlib is added as completions to many
commands, which I find rather noisy and rarely useful.

Before:

    [~/check]% go install <Tab>
    archive/    context/    fmt/        log/        regexp/     testing/
    bufio/      crypto/     go/         math/       runtime/    text/
    builtin/    database/   hash/       mime/       sort/       time/
    bytes/      debug/      html/       net/        strconv/    unicode/
    check.go    encoding/   image/      os/         strings/    unsafe/
    cmd/        errors/     index/      path/       sync/       vendor/
    compress/   expvar/     internal/   plugin/     syscall/
    container/  flag/       io/         reflect/    testdata/

After:

    [~/check]% go install <Tab>
    # completes to ./check.go, which is the only file in this small package.

Also add a setting to disable GOPATH, as it's kind deprecated and on its
way out. Sometimes I have some stuff "go get"'d in there, but I rarely
want that as completions.

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [ ] This compdef is not already available in zsh.
- [ ] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [ ] This is a finished work.
- [ ] It has a header containing authors, status and origin of the script.
- [ ] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
