### PR TITLE
Add 'mssh' completion

### DIFF
--- a/src/_mssh
+++ b/src/_mssh
@@ -1,5 +1,28 @@
 #compdef mssh
-
+# ------------------------------------------------------------------------------
+# Copyright (c) 2020 Hyeon Kim
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+# ------------------------------------------------------------------------------
+# Description
+# -----------
 # mssh is a Python client for accessing EC2 instances via AWS EC2 Instance
 # Connect.
 #
@@ -7,6 +30,14 @@
 #   https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-methods.html#ec2-instance-connect-connecting-ec2-cli
 #   https://github.com/aws/aws-ec2-instance-connect-cli
 #   https://pypi.org/project/ec2instanceconnectcli/
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Hyeon Kim (https://hyeon.me/)
+#
+# ------------------------------------------------------------------------------
 
 # Define function only when it doesn't exist
 (( $+functions[_mssh_cache_policy] )) || _mssh_cache_policy() {

--- a/src/_mssh
+++ b/src/_mssh
@@ -1,0 +1,52 @@
+#compdef mssh
+
+# mssh is a Python client for accessing EC2 instances via AWS EC2 Instance
+# Connect.
+#
+# References:
+#   https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-methods.html#ec2-instance-connect-connecting-ec2-cli
+#   https://github.com/aws/aws-ec2-instance-connect-cli
+#   https://pypi.org/project/ec2instanceconnectcli/
+
+# Define function only when it doesn't exist
+(( $+functions[_mssh_cache_policy] )) || _mssh_cache_policy() {
+  # Cache invalidates after 30 seconds
+  #
+  # Reference:
+  #   http://zsh.sourceforge.net/Doc/Release/Expansion.html#index-globbing_002c-qualifiers
+  local -a oldp
+  oldp=( "$1"(ms+30) )
+  (( $#oldp ))
+}
+
+# Unless user explicitly turned off caching, enable caching just for this context
+local existing_setting
+zstyle -s ":completion:${curcontext}:" use-cache existing_setting
+if [[ -z "${existing_setting}" ]]; then
+  zstyle ":completion:${curcontext}:" use-cache on
+fi
+
+# Update cache policy only when there was no existing policy
+local existing_policy
+zstyle -s ":completion:${curcontext}:" cache-policy existing_policy
+if [[ -z "${existing_policy}" ]]; then
+  zstyle ":completion:${curcontext}:" cache-policy _mssh_cache_policy
+fi
+
+local -a instances
+if _cache_invalid mssh_instances || ! _retrieve_cache mssh_instances; then
+  # Cache is invalid or caching feature is disabled
+  IFS=$'\n\t' instances=($(
+    aws ec2 describe-instances \
+      --query 'Reservations[].Instances[] | [?State.Name == `running`].join(`:`, [InstanceId, Tags[?Key == `Name`].Value | [0]])' \
+      --output text
+  ))
+
+  _store_cache mssh_instances instances
+fi
+
+_describe 'command' instances
+
+# Reference:
+#   http://zsh.sourceforge.net/Doc/Release/Completion-System.html
+#   https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org


### PR DESCRIPTION
mssh is a Python client for accessing EC2 instances via AWS EC2 Instance Connect. This autocompletion automatically look up for the EC2 instance id.

![image](https://user-images.githubusercontent.com/4435445/103347655-f2194380-4ada-11eb-8c0b-a4be31335112.png)

https://user-images.githubusercontent.com/4435445/103350735-42e16a00-4ae4-11eb-83e3-673c5caac3cf.mp4

You can try with my [fork](https://github.com/simnalamburt/zsh-completions):

```
zinit light simnalamburt/zsh-completions
```

#### References
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-methods.html#ec2-instance-connect-connecting-ec2-cli
- https://github.com/aws/aws-ec2-instance-connect-cli
- https://pypi.org/project/ec2instanceconnectcli/

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

#### Checklist

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
