### PR TITLE
Fix completion of cipher algorithms

### DIFF
--- a/src/_openssl
+++ b/src/_openssl
@@ -611,7 +611,9 @@ _openssl_gendsa() {
 _openssl_genpkey() {
   # written for openssl 1.0.1k
   local ciphers cipher_opts
-  ciphers=( ${$(openssl list-cipher-algorithms | cut -d' ' -f1)} )
+  if ! ciphers=( ${$(openssl list-cipher-algorithms | cut -d' ' -f1)} ) 2>/dev/null ; then
+    ciphers=( ${$(openssl list -cipher-algorithms | cut -d' ' -f1)} )
+  fi
   cipher_opts=()
   for alg in ${ciphers}; do
     cipher_opts=(${cipher_opts} "(${${(l:32:: ::-:)ciphers[@]}//  / })-${alg}[use this cipher to encrypt the key]")


### PR DESCRIPTION
Tab-completing `openssl` would give an error about the `list-cipher-algorithms` being an invalid command. The correct command seems to be `list -cipher-algorithms` (notice the space).

<img width="774" alt="openssl" src="https://user-images.githubusercontent.com/28014843/103469113-ea6ad080-4d60-11eb-9b2a-89ca76a93095.png">
