### PR TITLE
udisksctl: fix paths with a colon

### DIFF
--- a/src/_udisksctl
+++ b/src/_udisksctl
@@ -52,7 +52,7 @@
 _paths() {
     local -a _path_list
 
-    for _path in $(_call_program paths "udisksctl complete \"udisksctl $words\" $CURSOR"); do
+    for _path in $(_call_program paths "udisksctl complete \"udisksctl $words\" $CURSOR" | sed 's/:/\\:/g'); do
         _path_list+=$_path
     done
 


### PR DESCRIPTION
For paths such as `/dev/disk/by-id/usb-JetFlash_Transcend_64GB_15AFGA849642-0:0`, `_describe` parses the colon as field separator. This results in wrong completions and the general feeling that udisksctl is broken because it won't mount my pendrive.

Since the output of `udisksctl complete` is (apparently) just a list of paths, it's safe to escape all colons with a backslash.

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
