### PR TITLE
Add completion for gpgconf

### DIFF
--- a/src/_gpgconf
+++ b/src/_gpgconf
@@ -37,6 +37,7 @@ _arguments \
     '--check-options[check options]:component:_gpgconf_component' \
     '--apply-profile[update configuration files using the specified file]:configuration file:_path_files' \
     '--status-fd[write status info to the specified file descriptor]:file descriptor' \
+    '--homedir[specify an alternative gnupg configuration home directory]:directory:_directories' \
     '(-o --output)'{-o,--output}'[write output to the specified file]:output file:_path_files' \
     '(-v --verbose)'{-v,--verbose}'[verbose]' \
     '(-q --quiet)'{-q,--quiet}'[quiet]' \

--- a/src/_gpgconf
+++ b/src/_gpgconf
@@ -8,8 +8,7 @@
 
 _gpgconf_component() {
   local values=(
-    "${(@f)$(gpgconf --list-components \
-        | perl -lne 'my ($name, $desc, $x) = split /:/; print "${name}[$desc]"')}"
+    "${(@f)$(gpgconf --list-components | perl -F: -ale 'print "${F[0]}[$F[1]]"')}"
   )
   if [ "${action[2]}" = all ]; then
     values+=('all[All daemon components]')

--- a/src/_gpgconf
+++ b/src/_gpgconf
@@ -1,4 +1,29 @@
 #compdef gpgconf
+# Copyright (c) 2021 Github zsh-users - http://github.com/zsh-users
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the zsh-users nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL ZSH-USERS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 # Description:
 #     Completions for gpgconf (configuration utility provided with GnuPG
 #     <https://gnupg.org>)

--- a/src/_gpgconf
+++ b/src/_gpgconf
@@ -1,0 +1,44 @@
+#compdef gpgconf
+# Description:
+#     Completions for gpgconf (configuration utility provided with GnuPG
+#     <https://gnupg.org>)
+#
+# Authors:
+#   * "score" <seejay.11@gmail.com> https://keybase.io/score_under
+
+_gpgconf_component() {
+  local values=(
+    "${(@f)$(gpgconf --list-components \
+        | perl -lne 'my ($name, $desc, $x) = split /:/; print "${name}[$desc]"')}"
+  )
+  if [ "${action[2]}" = all ]; then
+    values+=('all[All daemon components]')
+  fi
+
+  _values 'component' "${(o)values[@]}"
+}
+
+_arguments \
+    '--help[print help text]' \
+    '--list-components[list all components]' \
+    '--check-programs[check all programs]' \
+    '--apply-defaults[apply global default values]' \
+    '--list-dirs[get the configuration directories for gpgconf]' \
+    '--list-config[list global configuration file]' \
+    '--check-config[check global configuration file]' \
+    '--query-swdb[query the software version database]' \
+    '--reload[reload all or a given component]:component:_gpgconf_component all' \
+    '--launch[launch a given component]:component:_gpgconf_component all' \
+    '--kill[kill a given component]:component:_gpgconf_component all' \
+    '--create-socketdir[create a directory for sockets below /run/user or /var/run/user]' \
+    '--remove-socketdir[remove a directory created with command --create-socketdir]' \
+    '--list-options[list options]:component:_gpgconf_component' \
+    '--change-options[change options]:component:_gpgconf_component' \
+    '--check-options[check options]:component:_gpgconf_component' \
+    '--apply-profile[update configuration files using the specified file]:configuration file:_path_files' \
+    '--status-fd[write status info to the specified file descriptor]:file descriptor' \
+    '(-o --output)'{-o,--output}'[write output to the specified file]:output file:_path_files' \
+    '(-v --verbose)'{-v,--verbose}'[verbose]' \
+    '(-q --quiet)'{-q,--quiet}'[quiet]' \
+    '(-n --dry-run)'{-n,--dry-run}'[do not make any changes]' \
+    '(-r --runtime)'{-r,--runtime}'[activate changes at runtime, if possible]'


### PR DESCRIPTION
- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] ~~It has a license header or~~ I accept that it will be licensed under the terms of the Zsh license.

This could probably be improved if `--list-config` and `--check-config` also completed an optional filename, but I don't know if optional arguments are possible in zsh completion (and specifying the arguments list itself as a possible alternative completion results in a stack overflow), so this is as far as I can take the script myself.