### PR TITLE
Update nano to version 5.4

### DIFF
--- a/src/_nano
+++ b/src/_nano
@@ -16,9 +16,11 @@ _arguments -s -C \
   {-L,--nonewlines}'[Do not add an automatic newline]'\
   {-M,--trimblanks}'[Trim tail spaces when hard-wrapping]'\
   {-N,--noconvert}'[Do not convert files from DOS/Mac format]'\
+  {-O,--bookstyle}'[Leading whitespace means new paragraph]'\
   {-P,--positionlog}'[Log & read location of cursor position]'\
   {-Q+,--quotestr=}'[Regular expression to match quoting]:str'\
   {-R,--restricted}'[Restricted mode]'\
+  {-S,--softwrap}'[Display overlong lines on multiple rows]'\
   {-T+,--tabsize=}'[Set width of a tab to cols columns]:init'\
   {-U,--quickblank}'[Do quick statusbar blanking]'\
   '(- *)'{-V,--version}'[Print version information and exit]'\
@@ -42,13 +44,16 @@ _arguments -s -C \
   {-n,--noread}'[Do not read the file (only write it)]'\
   {-o+,--operatingdir=}'[Set operating directory]:dir:_dirs'\
   {-p,--preserve}'[Preserve XON (^Q) and XOFF (^S) keys]'\
+  {-q,--indicator}'[Show a position+portion indicator]'\
   {-r+,--fill=}'[Set width for hard-wrap and justify]:init'\
   {-s+,--speller=}'[Enable alternate speller]:prog'\
   {-t,--tempfile}'[Auto save on exit, do not prompt]'\
   {-u,--unix}'[Save a file by default in Unix format]'\
+  {-v,--view}'[View mode (read-only)]'\
   {-w,--nowrap}'[Do not hard-wrap long lines default]'\
   {-x,--nohelp}'[Do not show the two help lines]'\
   {-y,--afterends}'[Make Ctrl+Right stop at word ends]'\
   {-z,--suspend}'[Enable suspension]'\
+  {-%,--stateflags}'[Show some states on the title bar]'\
   {-$,--softwrap}'[Enable soft line wrapping]'\
    '(-t -q)*:file:_files'


### PR DESCRIPTION
<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [ ] This compdef is not already available in zsh.
- [ ] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [ ] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.

## Description
- I added five new options for nano.
  - `{-O,--bookstyle}`
  - `{-S,--softwrap}`
  - `{-q,--indicator}`
  - `{-v,--view}`
  - `{-%,--stateflags}`
- By the way, `{-$,--softwrap}` is deprecated, but I'm not sure whether we should remove it completely or not.

## Reference
- https://nano-editor.org/news.php