### PR TITLE
Autocomplete files for mix run

### DIFF
--- a/src/_mix
+++ b/src/_mix
@@ -227,11 +227,7 @@ case $state in
          _arguments ':feature:__task_list'
          return
       ;;
-      (test)
-         _arguments ':PATH:_files'
-         return
-      ;;
-      (format)
+      (test|format|run)
          _arguments ':PATH:_files'
          return
       ;;


### PR DESCRIPTION
Previously, `mix run <tab>` would not expand into anything, even though the [`mix run`](https://hexdocs.pm/mix/Mix.Tasks.Run.html) task accepts filenames as inputs. This commit collapses the growing list of such cases (`test`, `format`, `run`) into one clause that autocompletes files.

Although `mix run` accepts several different `--flags`, the autocompletion isn't currently set up to deal with subcommands' specific options, so I'm punting on that part.