### PR TITLE
Remove deprecated `-$` option

### DIFF
--- a/src/_nano
+++ b/src/_nano
@@ -20,7 +20,7 @@ _arguments -s -C \
   {-P,--positionlog}'[Log & read location of cursor position]'\
   {-Q+,--quotestr=}'[Regular expression to match quoting]:str'\
   {-R,--restricted}'[Restricted mode]'\
-  {-S,--softwrap}'[Display overlong lines on multiple rows]'\
+  {-S,--softwrap}'[Display overly long lines on multiple rows]'\
   {-T+,--tabsize=}'[Set width of a tab to cols columns]:init'\
   {-U,--quickblank}'[Do quick statusbar blanking]'\
   '(- *)'{-V,--version}'[Print version information and exit]'\
@@ -55,5 +55,4 @@ _arguments -s -C \
   {-y,--afterends}'[Make Ctrl+Right stop at word ends]'\
   {-z,--suspend}'[Enable suspension]'\
   {-%,--stateflags}'[Show some states on the title bar]'\
-  {-$,--softwrap}'[Enable soft line wrapping]'\
    '(-t -q)*:file:_files'


### PR DESCRIPTION
<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
