### PR TITLE
fix (( $+functions[_f] )) || _f()

### DIFF
--- a/src/_conan
+++ b/src/_conan
@@ -483,7 +483,7 @@ _conan_conanfiles() {
   _files -g '*.py'
 }
 
-(( $+functions[_conan_directory_or_package_references] )) ||
+(( $+functions[_conan_conanfiles_or_package_references] )) ||
 _conan_conanfiles_or_package_references() {
   _alternative \
     'conanfile: :_conan_conanfiles' \

--- a/src/_flutter
+++ b/src/_flutter
@@ -375,7 +375,7 @@ _arguments -C -A "-*" \
   }
 
   
-(( $+functions[root_commands] )) ||
+(( $+functions[_root_commands] )) ||
 _root_commands() {
   local commands;
   commands=(

--- a/src/_pygmentize
+++ b/src/_pygmentize
@@ -75,7 +75,7 @@ _get_filters() {
 }
 
 
-(( $+functions[_pygmentize_get_formatters] )) ||
+(( $+functions[_get_formatters] )) ||
 _get_formatters() {
   local cache_policy
   zstyle -s ":completion:${curcontext}:" cache-policy cache_policy


### PR DESCRIPTION
I was working on _conan when I saw an inconsistency in functions presence check

so, I checked all the repo with this regex: `\(\( \$\+functions\[(.*)\] \)\) \|\|\n(?!\1)`

If it can be helpful