### PR TITLE
Add completion for gti software

### DIFF
--- a/src/_gti
+++ b/src/_gti
@@ -1,0 +1,38 @@
+#compdef gti=git
+#
+# Copyright 2021 Mikhail f. Shiryaev
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# --------------------------------------------------------------------------------------
+# Descritpion
+# -----------
+#
+# Completion script for https://github.com/rwos/gti
+#
+# --------------------------------------------------------------------------------------
+# Authors
+# -------
+#
+# * Mikhail f. Shiryaev <mr dot felixoid at gmail dot com> (https://github.com/Felixoid)
+#
+# --------------------------------------------------------------------------------------
+
+type -w _git | grep -q function && \
+  _git


### PR DESCRIPTION
<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->
Hello. Here's a simple implementation of completion for gti software.

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
