### PR TITLE
xinput: escape colons in device names

### DIFF
--- a/src/_xinput
+++ b/src/_xinput
@@ -114,7 +114,7 @@ _xinput(){
 		[[ -n "$i" ]] || continue
 		xinput_devices_id+=($i)
 		name="$(xinput list --name-only $i)"
-		xinput_devices_name+=($name)
+		xinput_devices_name+=(${name//:/\\:})
 		xinput_devices+=($i\:$name)
 	done
 	xinput_devices+=($xinput_devices_name)


### PR DESCRIPTION
The completion menu breaks if any device names have colons in them, as colons are used to separate completion matches from their descriptions.