### PR TITLE
fix: entrypoint fpath expansion

### DIFF
--- a/zsh-completions.plugin.zsh
+++ b/zsh-completions.plugin.zsh
@@ -1,1 +1,1 @@
-fpath+="${0:h}/src"
+fpath+="${0:A:h}/src"


### PR DESCRIPTION
If I'm in `zsh-completions` directory and I source `zsh-completions.plugin.zsh`,

`"${0:h}/src"` was expnaded to `./src`, which is not what we want.

The updated `"${0:A:h}/src"` is expanded to `/full/absolute/path/to/zsh-completions/src`.