### PR TITLE
Fix perl one liner bug

### DIFF
--- a/src/_yarn
+++ b/src/_yarn
@@ -116,7 +116,7 @@ _yarn_commands_scripts() {
   fi
 
   if [[ -n $packageJson ]]; then
-    scripts=($(cat "$packageJson" | perl -0777 -MJSON::PP -n -E '%r=decode_json($_); say for sort keys %{$r->{scripts}}'))
+    scripts=($(cat "$packageJson" | perl -0777 -MJSON::PP -n -E '$r=decode_json($_); say for sort keys %{$r->{scripts}}'))
   fi
 
   _describe 'command or script' _commands -- _global_commands -- scripts -- binaries


### PR DESCRIPTION
decode_json returns hash reference, so scalar variable should be
used instead of hash variable.

#833 

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
