### PR TITLE
Fix script completion which contains colons

### DIFF
--- a/src/_yarn
+++ b/src/_yarn
@@ -116,7 +116,7 @@ _yarn_commands_scripts() {
   fi
 
   if [[ -n $packageJson ]]; then
-    scripts=($(cat "$packageJson" | perl -0777 -MJSON::PP -n -E '$r=decode_json($_); say for sort keys %{$r->{scripts}}'))
+    scripts=($(cat "$packageJson" | perl -0777 -MJSON::PP -n -E '$r=decode_json($_); do{($k=$_)=~s/:/\\:/g;say $k}for sort keys %{$r->{scripts}}'))
   fi
 
   _describe 'command or script' _commands -- _global_commands -- scripts -- binaries
@@ -144,7 +144,7 @@ _yarn_scripts() {
   fi
 
   if [[ -n $packageJson ]]; then
-    scripts=("${(@f)$(cat ${packageJson} | perl -0777 -MJSON::PP -n -E '%r=%{decode_json($_)->{scripts}}; printf "$_:$r{$_}\n" for sort keys %r')}")
+    scripts=("${(@f)$(cat ${packageJson} | perl -0777 -MJSON::PP -n -E '%r=%{decode_json($_)->{scripts}}; do{$k=$_;($e=$k)=~s/:/\\:/g; printf "$e:$r{$k}\n"} for sort keys %r')}")
   fi
 
   commands=('env' $scripts $binaries)


### PR DESCRIPTION
<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.


https://github.com/zsh-users/zsh-completions/issues/520#issuecomment-1006413444