### PR TITLE
Add initial natnetwork handling to virtualbox

### DIFF
--- a/src/_virtualbox
+++ b/src/_virtualbox
@@ -21,6 +21,14 @@ _vboxmachines() {
 	done
 }
 
+# Get natnetworks
+_vboxnatnets() {
+  vboxmanage list natnetworks | awk -F: '/NetworkName:/{print $2}'| while read natnet; do
+    _wanted 'natnet' expl 'natnet' compadd $natnet
+  done
+}
+
+
 # Roughly guess command options
 _vboxcommandoptions() {
 	cmd="$1"

--- a/src/_virtualbox
+++ b/src/_virtualbox
@@ -274,6 +274,16 @@ _vboxmanage() {
 				'--readonly' \
 				'--automount'
 		;;
+    natnetwork)
+      _arguments \
+        ':action:(add modify remove start stop)' \
+        '--netname:natnet:_vboxnatnets' \
+        '--dhcp:bool:(on off)' \
+        '--ipv6:bool:(on off)' \
+        '--enable' \
+        '--disable'
+      ;;
+
 	esac
 	return 1
 }

--- a/src/_virtualbox
+++ b/src/_virtualbox
@@ -1,4 +1,4 @@
-#compdef VBoxManage=vboxmanage VBoxHeadless=vboxheadless
+#compdef VBoxManage=vboxmanage VBoxHeadless=vboxheadless vboxmanage=vboxmanage
 # ------------------------------------------------------------------------------
 # Description
 # -----------

--- a/src/_virtualbox
+++ b/src/_virtualbox
@@ -21,13 +21,11 @@ _vboxmachines() {
 	done
 }
 
-# Get natnetworks
 _vboxnatnets() {
   vboxmanage list natnetworks | awk -F: '/NetworkName:/{print $2}'| while read natnet; do
     _wanted 'natnet' expl 'natnet' compadd $natnet
   done
 }
-
 
 # Roughly guess command options
 _vboxcommandoptions() {
@@ -135,6 +133,7 @@ _vboxmanage() {
 		'hostonlyif:change the IP configuration of a host-only network interface'
 		'dhcpserver:control the DHCP server that is built into VirtualBox'
 		'extpack:add or remove VirtualBox extension packs'
+		'natnetwork:add,modify,remove or start NatNetworks'
 	)
 
 	local context state line expl
@@ -151,7 +150,7 @@ _vboxmanage() {
 		list)
 			_arguments \
 				'--long' \
-				':list option:(vms runningvms ostypes hostdvds hostfloppies bridgedifs hostonlyifs dhcpservers hostinfo hostcpuids hddbackends hdds dvds floppies usbhost usbfilters systemproperties extpacks)'
+				':list option:(vms runningvms ostypes hostdvds hostfloppies bridgedifs hostonlyifs dhcpservers hostinfo hostcpuids hddbackends hdds dvds floppies usbhost usbfilters systemproperties natnetworks extpacks)'
 		;;
 		showvminfo)
 			_arguments \


### PR DESCRIPTION
<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [ ] This compdef is not already available in zsh.
- [ ] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [ ] This is a finished work.
- [ ] It has a header containing authors, status and origin of the script.
- [ ] It has a license header or I accept that it will be licensed under the terms of the Zsh license.

This PR adds initial support for the `natnetwork`subcommand in `vboxmanage`. I also include `vboxmanage=vboxmanage`to make the completion more comfortable to use in Linux.
 