### PR TITLE
Rewrite #849 in Perl for portability

### DIFF
--- a/src/_cmake
+++ b/src/_cmake
@@ -141,21 +141,14 @@ _cmake_generator_options() {
 # --------------
 (( $+functions[_cmake_presets] )) ||
 _cmake_presets() {
-
-  local parse_presets; parse_presets='
-import json    
-import os    
-try:    
-    with open("CMakePresets.json") as preset_file:    
-        print(os.linesep.join([ x["name"] + ":" + x.get("description", "") for x in json.load(preset_file)["configurePresets"]]))
-except:    
-    pass    
-
-'
-
   # TODO: Problems with quotes need eval
   # would need a way to exec the array
-  local list_presets; list_presets=(${(f)"$(eval python <<< $parse_presets)"})
+  local -a list_presets;
+
+  if [[ -e CMakePresets.json ]]; then
+    # some old projects uses BOM in json file. strip UTF-8 BOM and then parse JSON
+    list_presets=("${(@f)$(sed '1s/^\xEF\xBB\xBF//' < CMakePresets.json | perl -0777 -MJSON::PP -nE 'do{$k=$_;($e=$k)=~s/:/\\:/g; printf "$_->{name}:$_->{description}\n"} for @{decode_json($_)->{configurePresets}}' 2>/dev/null)}")
+  fi
 
   _describe 'presets' list_presets
 }

--- a/src/_cmake
+++ b/src/_cmake
@@ -141,13 +141,21 @@ _cmake_generator_options() {
 # --------------
 (( $+functions[_cmake_presets] )) ||
 _cmake_presets() {
-  local invoke; invoke=(${words[@]})
-  # TODO: remove all arguments -* except -S
-  invoke[$CURRENT]=--list-presets
+
+  local parse_presets; parse_presets='
+import json    
+import os    
+try:    
+    with open("CMakePresets.json") as preset_file:    
+        print(os.linesep.join([ x["name"] + ":" + x.get("description", "") for x in json.load(preset_file)["configurePresets"]]))
+except:    
+    pass    
+
+'
 
   # TODO: Problems with quotes need eval
   # would need a way to exec the array
-  local list_presets; list_presets=(${(f)"$(eval "${invoke[@]} 2> /dev/null" | grep -Po '(?<=\").*(?=")' )"})
+  local list_presets; list_presets=(${(f)"$(eval python <<< $parse_presets)"})
 
   _describe 'presets' list_presets
 }

--- a/src/_cmake
+++ b/src/_cmake
@@ -147,7 +147,7 @@ _cmake_presets() {
 
   # TODO: Problems with quotes need eval
   # would need a way to exec the array
-  local list_presets; list_presets=(${(f)"$(eval "${invoke[@]} 2> /dev/null" | sed -n 's,^[[:space:]]*"\([^"]*\)"[[:space:]]*-[[:space:]]*\(.*\),\1:\2,p' )"})
+  local list_presets; list_presets=(${(f)"$(eval "${invoke[@]} 2> /dev/null" | grep -Po '(?<=\").*(?=")' )"})
 
   _describe 'presets' list_presets
 }


### PR DESCRIPTION
<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.

This rewrites the #849 patch in Perl for portability