### PR TITLE
Drop unsupported git protocol from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Add `zinit light zsh-users/zsh-completions` to your `~/.zshrc`.
 
 * Clone the repository:
 
-        git clone git://github.com/zsh-users/zsh-completions.git
+        git clone https://github.com/zsh-users/zsh-completions.git
 
 * Include the directory in your `$fpath`, for example by adding in `~/.zshrc`:
 


### PR DESCRIPTION
When trying to clone the repository, git complained with:
```
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
```

Using HTTPS in the URL works just fine.