### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Note: adding it as a regular Oh My ZSH! plugin will not work properly (see [#603
 
 Add `zinit light zsh-users/zsh-completions` to your `~/.zshrc`.
 
+### Using Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `zsh-completions` in just one click.
+
+<a href="https://fig.io/plugins/other/zsh-completions" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### Manual installation
 
 * Clone the repository:


### PR DESCRIPTION
<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [ ] This compdef is not already available in zsh.
- [ ] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [ ] This is a finished work.
- [ ] It has a header containing authors, status and origin of the script.
- [ ] It has a license header or I accept that it will be licensed under the terms of the Zsh license.

## PR Description

The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

Zsh completions is one of the most popular plugins on our store (it's on our front page!), so we'd really love to have Fig listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!


