### PR TITLE
_cmake: fix cmake presets for real

### DIFF
--- a/src/_cmake
+++ b/src/_cmake
@@ -141,14 +141,13 @@ _cmake_generator_options() {
 # --------------
 (( $+functions[_cmake_presets] )) ||
 _cmake_presets() {
-  # TODO: Problems with quotes need eval
-  # would need a way to exec the array
-  local -a list_presets;
+  local invoke; invoke=(${(Q)words})
+  invoke[$CURRENT]=()
+  # TODO: remove all arguments -* except -S
 
-  if [[ -e CMakePresets.json ]]; then
-    # some old projects uses BOM in json file. strip UTF-8 BOM and then parse JSON
-    list_presets=("${(@f)$(sed '1s/^\xEF\xBB\xBF//' < CMakePresets.json | perl -0777 -MJSON::PP -nE 'do{$k=$_;($e=$k)=~s/:/\\:/g; printf "$_->{name}:$_->{description}\n"} for @{decode_json($_)->{configurePresets}}' 2>/dev/null)}")
-  fi
+  local list_presets; list_presets=(${(f)"$(${invoke} --list-presets 2>/dev/null |
+    sed -n -e 's,^[[:space:]]*"\([^"]*\)"[[:space:]]*-[[:space:]]*\(.*\),\1:\2,p' \
+           -e 's,^[[:space:]]*"\([^"]*\)"[[:space:]]*$,\1,p')"})
 
   _describe 'presets' list_presets
 }


### PR DESCRIPTION
There was an issue with the original code not supporting presets
without description.
Additionally it did not fully work with newer cmake versions, as the
`--list-preset` switch was changed to have an optional argument
and has to be added at the end of the commandline because of that.

Previous fixes (#849) made matters worse, as the did not take into account
that the CMake Project might not be the one in the current working directory,
this reverts those changes.
