### PR TITLE
Update for go 1.19

### DIFF
--- a/src/_golang
+++ b/src/_golang
@@ -30,7 +30,7 @@
 # Description
 # -----------
 #
-#  Completion script for go 1.18 (http://golang.org).
+#  Completion script for go 1.19 (http://golang.org).
 #
 # ------------------------------------------------------------------------------
 # Authors
@@ -144,7 +144,6 @@ __go_gcflags() {
   '-goversion=[required version of the runtime]:string' \
   '-h[halt on error]' \
   '-importcfg=[read import configuration from file]:file' \
-  '-importmap=[add definition of the form source=actual to import map]:definition' \
   '-installsuffix=[set pkg directory suffix]:suffix' \
   '-j[debug runtime-initialized variables]' \
   '-json=[version,destination for JSON compiler/optimizer logging]:string' \
@@ -811,7 +810,6 @@ case $state in
                   '-g[debug code generation]' \
                   '-h[halt on error]' \
                   '-i[debug line number stack]' \
-                  '-importmap[add definition of the form source=actual to import map]:definition' \
                   '-installsuffix[set pkg directory suffix]:suffix' \
                   '-j[debug runtime-initialized variables]' \
                   '-l[disable inlining]' \


### PR DESCRIPTION
'tool compile' no longer accepts '-importmap'

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
