### PR TITLE
Add Fig as installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Note: adding it as a regular Oh My ZSH! plugin will not work properly (see [#603
 
 Add `zinit light zsh-users/zsh-completions` to your `~/.zshrc`.
 
+### Using [Fig](https://fig.io)
+
+Click [here](https://fig.io/plugins/other/zsh-completions) to 1-click install `zsh-completions`
+
 ### Manual installation
 
 * Clone the repository:


### PR DESCRIPTION
Just wanted to create a fresh thread for adding Fig as an installation method. Previous thread was here: https://github.com/zsh-users/zsh-completions/pull/868/files

I have updated the wording, taking into account all the commentary from the other threads.

Apologies again for the issues above - please let me know if any more questions/concerns! 

Brendan