### PR TITLE
make httpie completion work for both `http` and `https`

### DIFF
--- a/src/_httpie
+++ b/src/_httpie
@@ -1,4 +1,4 @@
-#compdef http
+#compdef http https=http
 # ------------------------------------------------------------------------------
 # Copyright (c) 2015 Github zsh-users - http://github.com/zsh-users
 # All rights reserved.


### PR DESCRIPTION
<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.

`httpie` provides both the `http` and `https` command. Let's make the completion work for both.