### PR TITLE
Utilize grep -E instead of deprecated/obsolescent egrep

### DIFF
--- a/src/_vagrant
+++ b/src/_vagrant
@@ -156,7 +156,7 @@ __vm_list ()
     then
       _vagrant_vms=( $(_call_program path-all "vagrant status | \
                        awk '{print \$1}' | \
-                       egrep -v '^$|^(Current|This|above|VM,)$'" ) )
+                       grep -Ev '^$|^(Current|This|above|VM,)$'" ) )
       _store_cache VAGRANT_VMS _vagrant_vms
     fi
 

--- a/src/_virtualbox
+++ b/src/_virtualbox
@@ -16,7 +16,7 @@
 
 
 _vboxmachines() {
-	VBoxManage list vms | egrep -o '^"[^"]+"' 2>/dev/null | sed -e 's|"||g' | while read machine; do
+	VBoxManage list vms | grep -Eo '^"[^"]+"' 2>/dev/null | sed -e 's|"||g' | while read machine; do
 		_wanted 'machine' expl 'machine' compadd $machine
 	done
 }
@@ -35,7 +35,7 @@ _vboxcommandoptions() {
 	optcount=0
 	option=""
 	optlines=()
-	echo "$cmdoutput" | egrep -o '  [\[A-Za-z0-9\-\<].*' | while read line; do
+	echo "$cmdoutput" | grep -Eo '  [\[A-Za-z0-9\-\<].*' | while read line; do
 		option="${option}${line}"
 		if [[ $line[-1] != '|' ]]; then
 			optcount=$(($optcount+1))
@@ -46,7 +46,7 @@ _vboxcommandoptions() {
 
 	# optionals ([abc])
 	for line in $optlines; do
-		echo "$line" | egrep -o '\[[^]]+\]' | while read option; do
+		echo "$line" | grep -Eo '\[[^]]+\]' | while read option; do
 			option=$(echo $option | sed 's|[]\[]||g' | cut -d ' ' -f 1)
 			_options=(${(s:|:)option})
 			for option in $_options; do


### PR DESCRIPTION
This PR changes the vagrant and virtualbox completions so they utilize `grep -E` instead of calling `egrep`. 


