### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,32 @@ Note: adding it as a regular Oh My ZSH! plugin will not work properly (see [#603
 
 Add `zinit light zsh-users/zsh-completions` to your `~/.zshrc`.
 
+### Using Homebrew
+
+### [Brew](https://github.com/Homebrew/brew)
+* Install command:
+        
+        brew install zsh-completions
+
+* To activate these completions, add the following to your `~/.zshrc`:
+
+    ```sh
+    if type brew &>/dev/null; then
+     FPATH=$(brew --prefix)/share/zsh-completions:$FPATH
+
+     autoload -Uz compinit
+     compinit
+    fi
+    ```
+
+* You may also need to force rebuild `zcompdump`:
+
+        rm -f ~/.zcompdump; compinit
+
+* Additionally, if you receive `"zsh compinit: insecure directories"` warnings when attempting to load these completions, you may need to run this:
+
+        chmod -R go-w '$(brew --prefix)/share/zsh'
+        
 ### Manual installation
 
 * Clone the repository:


### PR DESCRIPTION
Adds step to install zsh-completions using Homebrew Formulae.

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [ ] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
