### PR TITLE
Original sed code does not work on BSD sed with BRE

### DIFF
--- a/src/_fvm
+++ b/src/_fvm
@@ -36,7 +36,7 @@
 
 _fvm_versions() {
   local -a versions
-  versions=($(fvm releases | grep -E '[0-9]+\.[0-9]+.[0-9]+' | sed -e 's/^.* \(v\?[0-9][0-9]*\.[^ ]*\).*$/\1/g'))
+  versions=($(fvm releases | awk '/[0-9]+\.[0-9]+\.[0-9]+/{ sub(/^[^│]*│ /, ""); print $1}'))
   versions=(master beta stable $versions)
   _describe 'versions' versions
 }


### PR DESCRIPTION
<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
