### PR TITLE
fix bundle group completion

### DIFF
--- a/src/_bundle
+++ b/src/_bundle
@@ -78,11 +78,8 @@ _bundle_gems() {
 }
 
 _bundle_groups() {
-  setopt extendedglob
-
-  local gemdir=$(echo (../)#Gemfile(:h))
-  if [[ -n $gemdir ]]; then
-    local -a groups=($(cd "$gemdir" && awk '/^ *group *:/{sub(/^ *group *:/, ""); print $1}' Gemfile))
+  if [[ -e Gemfile ]]; then
+    local -a groups=(${(@f)"$(awk '/^ *group *:/{sub(/^ *group *:/, ""); print $1}' Gemfile)"})
     _values 'groups' $groups
   fi
 }


### PR DESCRIPTION
Original code does not work if multile directories are matched

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
