### PR TITLE
nvm: remove extra space in exec command description

### DIFF
--- a/src/_nvm
+++ b/src/_nvm
@@ -167,7 +167,7 @@ __nvm_subcommands() {
     'install:Download and install a <version>'
     'uninstall:Uninstall a <version>'
     'use:Modify PATH to use <version>'
-    'exec: Run <command> on <version>'
+    'exec:Run <command> on <version>'
     'run:Run <version> with <args> as arguments'
     'current:Display currently activated version of Node'
     'ls:List installed [versions]'


### PR DESCRIPTION
<!-- Thank you so much for your PR! -->

minor typo fix: removes redundant space
