### PR TITLE
tmuxp: fix using workspace dirs other than ~/.tmuxp

### DIFF
--- a/src/_tmuxp
+++ b/src/_tmuxp
@@ -139,11 +139,18 @@ __tmuxp_load() {
   # Can't get the options to be recognized when there are sessions that has
   # a dash.
 
+  local tmuxp_dir="${HOME}/.tmuxp"
+  local tmuxp_xdg_dir="${XDG_CONFIG_HOME:-${HOME}/.config}"
+  if [[ -d "${TMUXP_CONFIGDIR-}" ]]; then
+    tmuxp_dir="${TMUXP_CONFIGDIR}"
+  elif [[ -d "${tmuxp_xdg_dir}" ]]; then
+    tmuxp_dir="${tmuxp_xdg_dir}"
+  fi
   case $state in
     (sessions)
       local s
       _alternative \
-        'sessions-user:user session:compadd -F line - ~/.tmuxp/*.(json|yml|yaml)(:r:t)' \
+        'sessions-user:user session:compadd -F line - ${tmuxp_dir}/*.(json|yml|yaml)(:r:t)' \
         'sessions-other:session in current directory:_path_files -/ -g "**/.tmuxp.(yml|yaml|json)"' \
         'sessions-other:session in current directory:_path_files -g "*.(yml|yaml|json)"'
       ;;


### PR DESCRIPTION
For reference see https://github.com/tmux-python/tmuxp/blob/3ba64262839da6a643a19e70bb990ca3e589ad16/src/tmuxp/workspace/finders.py#L99-L128


<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [ ] This compdef is not already available in zsh.
- [ ] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [ ] This is a finished work.
- [ ] It has a header containing authors, status and origin of the script.
- [ ] It has a license header or I accept that it will be licensed under the terms of the Zsh license.