### PR TITLE
Avoid defining local variable 'options'

### DIFF
--- a/src/_pkcon
+++ b/src/_pkcon
@@ -36,8 +36,8 @@
 # ------------------------------------------------------------------------------
 
 
-local -a options
-options=(
+local -a command_options
+command_options=(
   '--version[Show the program version and exit]'
   '--filter[Set the filter, e.g. installed]'
   "--root[Set the install root, e.g. '/' or '/mnt/ltsp']"
@@ -107,23 +107,23 @@ done
 
 if [[ -z "$cmd" ]]
 then
-  _arguments -s -w : $options \
+  _arguments -s -w : $command_options \
     ":action:($actions)"
   return
 fi
 
 case "$cmd" in
   search)
-    _arguments : $options \
+    _arguments : $command_options \
       ':type:(name details group file)' \
       ':data: :'
   ;;
   refresh)
-    _arguments -s -w : $options \
+    _arguments -s -w : $command_options \
       '--force'
   ;;
   *)
-    _arguments -s -w : $options
+    _arguments -s -w : $command_options
   ;;
 esac
 return 1

--- a/src/_virtualbox
+++ b/src/_virtualbox
@@ -339,9 +339,9 @@ _vboxmanage() {
             && ret=0
           ;;
         (modifyvm|export)
-          local -a options=(${(@f)"$(vboxmanage $words[1] | perl -wln -e 'm{(--[a-zA-Z_-]+) [^]|]+} and print qq{$1:arg}')"})
+          local -a command_options=(${(@f)"$(vboxmanage $words[1] | perl -wln -e 'm{(--[a-zA-Z_-]+) [^]|]+} and print qq{$1:arg}')"})
           _arguments \
-            $options \
+            $command_options \
             ':machine:_vboxmachines'
           ;;
         (controlvm)


### PR DESCRIPTION
zsh has the built in variable 'options'. zsh sometimes behaves weirdly when there is a local variable that is named 'options'

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
