### PR TITLE
Fix port's cache policy function

### DIFF
--- a/src/_port
+++ b/src/_port
@@ -253,15 +253,10 @@ _port_select() {
   fi
 }
 
-stat -f%m . > /dev/null 2>&1
-if [ "$?" = 0 ]; then
-  stat_cmd=(stat -f%Z)
-else
-  stat_cmd=(stat --format=%Z)
-fi
-
 _port_caching_policy() {
   local reg_time comp_time check_file
+
+  zmodload -F zsh/stat b:zstat 2> /dev/null
   case "${1##*/}" in
     PORT_INSTALLED_PACKAGES)
       check_file=$port_prefix/var/macports/registry/registry.db
@@ -270,9 +265,17 @@ _port_caching_policy() {
       check_file=${$(port dir MacPorts)%/*/*}/PortIndex
       ;;
   esac
-  reg_time=$($stat_cmd $check_file)
-  comp_time=$($stat_cmd $1)
+  reg_time=$(zstat +mtime $check_file)
+  comp_time=$(zstat +mtime $1)
   return $(( reg_time < comp_time ))
 }
 
 _port "$@"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et


### PR DESCRIPTION
The option of stat on macOS/BSD is wrong. So cache is always purged and cache is always recreated so it is really slow.

Use 'zstat' module instead stat command for portability.

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
