### PR TITLE
Support THC secure-delete

### DIFF
--- a/src/_srm
+++ b/src/_srm
@@ -36,38 +36,54 @@
 #
 # ------------------------------------------------------------------------------
 
-local -a opts args
+local -a args
+
 args=(
-  '(-f --force)'{-f,--force}'[ignore nonexistent files, never prompt]'
-  '(-r --interactive)'{-i,--interactive}'[prompt before any removal]'
-  '(-r -R --recursive)'{-r,-R,--recursive}'[remove the contents of directories recursively]'
-  '(-s --simple)'{-s,--simple}'[only overwrite with a single pass of random data]'
-  '(-v --verbose)'{-v,--verbose}'[explain what is being done]'
-  '(- *)--help[display help message and exit]'
-  '(- *)--version[output version information and exit]'
   '*::files:->file'
 )
 
-if _pick_variant gnu=gnu unix --help; then
+_pick_variant -r variant gnu=gnu thc=THC unix --help
+
+if [[ $variant == "thc" ]]; then
   args+=(
-    '(-x --one-file-system)'{-x,--one-file-system}'[stay within filesystems of files given as arguments]'
-    '(-P --openbsd)'{-P,--openbsd}'[overwrite the file 3 times (0xff, 0x00, 0xff)]'
-    '(-D --dod)'{-D,--dod}'[overwrite the file with 7 US DoD compliant passes (0xF6, 0x00, 0xFF, random, 0x00, 0xFF, random)]'
-    '(-E --doe)'{-E,--doe}'[overwrite the file with 3 US DoE compliant passes (random, random, DoE)]'
+    '-d[ignore the two special dot files . and .. on the commandline]'
+    '-f[fast (and insecure mode)]'
+    '*-l[lessens the security. -l for a second time lessons the security even more]'
+    '-r[recursive mode]'
+    '-v[verbose mode]'
+    '-z[wipes the last write with zeros instead of random data]'
   )
 else
   args+=(
-    '(-m --medium)'{-m,--medium}'[overwrite the file with 7 US DoD compliant passes (0xF6, 0x00, 0xFF, random, 0x00, 0xFF, random)]'
-    '(-z --zero)'{-z,--zero}'[after overwriting, zero blocks used by file]'
-    '(-n --nounlink)'{-n,--nounlink}'[overwrite file, but do not rename or unlink it]' 
+    '(-f --force)'{-f,--force}'[ignore nonexistent files, never prompt]'
+    '(-r --interactive)'{-i,--interactive}'[prompt before any removal]'
+    '(-r -R --recursive)'{-r,-R,--recursive}'[remove the contents of directories recursively]'
+    '(-s --simple)'{-s,--simple}'[only overwrite with a single pass of random data]'
+    '(-v --verbose)'{-v,--verbose}'[explain what is being done]'
+    '(- *)--help[display help message and exit]'
+    '(- *)--version[output version information and exit]'
   )
+
+  if [[ $variant == "gnu" ]]; then
+    args+=(
+      '(-x --one-file-system)'{-x,--one-file-system}'[stay within filesystems of files given as arguments]'
+      '(-P --openbsd)'{-P,--openbsd}'[overwrite the file 3 times (0xff, 0x00, 0xff)]'
+      '(-D --dod)'{-D,--dod}'[overwrite the file with 7 US DoD compliant passes (0xF6, 0x00, 0xFF, random, 0x00, 0xFF, random)]'
+      '(-E --doe)'{-E,--doe}'[overwrite the file with 3 US DoE compliant passes (random, random, DoE)]'
+    )
+  else
+    args+=(
+      '(-m --medium)'{-m,--medium}'[overwrite the file with 7 US DoD compliant passes (0xF6, 0x00, 0xFF, random, 0x00, 0xFF, random)]'
+      '(-z --zero)'{-z,--zero}'[after overwriting, zero blocks used by file]'
+      '(-n --nounlink)'{-n,--nounlink}'[overwrite file, but do not rename or unlink it]'
+    )
+  fi
 fi
 
 local curcontext=$curcontext state line ret=1
 local -A opt_args
 
-_arguments -s -S -C $opts \
-  $args && ret=0
+_arguments -s -S -C $args && ret=0
 
 case $state in
   (file)
@@ -82,3 +98,11 @@ case $state in
 esac
 
 return $ret
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et


### PR DESCRIPTION
Recent Linux distribution uses newer THC secure-delete and it only supports few options.

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
