### PR TITLE
Fix nftables completion: when object name contains its type name

### DIFF
--- a/src/_nftables
+++ b/src/_nftables
@@ -468,7 +468,7 @@ _nft_object(){
   #$3:object type (chain/set/map/flowtable/ct helper/counter/quota/meter)
   #$4:include 'handle'?
   local objects=( ${(f)"$(_call_program -p objects nft -a list table $1 $2 2>/dev/null\
-      | grep ""\\s\*$3"" | sed 's/\s*'"$3"' // ;s/ { # \(.*\)/:(\1)/' )"} )
+      | grep ""\^\\s\*$3"" | sed 's/\s*'"$3"' // ;s/ { # \(.*\)/:(\1)/' )"} )
   if $4 ;then
     objects+=( "handle:address $3 by handle")
   fi
@@ -481,7 +481,7 @@ _nft_object_handle(){
   #$2:table
   #$3:object type (chain/set/ct helper/counter/quota)
   local handles=( ${(f)"$(_call_program -p handles nft -a list table $1 $2 2>/dev/null\
-      | grep ""\\s\*$3"" | sed 's/\s*'"$3"' // ;s/ { # handle// ;s/\(\S*\) \(\S*\)/\2:\1/' )"} )
+      | grep ""\^\\s\*$3"" | sed 's/\s*'"$3"' // ;s/ { # handle// ;s/\(\S*\) \(\S*\)/\2:\1/' )"} )
   _describe -t handles "$3-handle" handles
 }
 


### PR DESCRIPTION
Fix nftables completion: when object name contains its type name, the completion may mass up

E.g.
```
table inet foo {
        chain my_chain {
                jump my_chain2
        }
        chain my_chain2 {
        }
}
```

`nft delete chain inet foo <tab>`
get
```
handle                          -- address chain by handle
my_chain2                       -- (handle 31)
my_chain                        -- (handle 30)
\t\tjump my_chain2 # handle 33
```
the last line in the completion output is not wanted.

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
