### PR TITLE
Add completions for sox

### DIFF
--- a/src/_rec
+++ b/src/_rec
@@ -1,9 +1,9 @@
-#compdef play
+#compdef rec
 # ------------------------------------------------------------------------------
 #
 # Description
 # -----------
-#  Completion script for the play command (from SoX)
+#  Completion script for the rec command (from SoX)
 #  (http://sox.sourceforge.net/)
 #
 # Authors

--- a/src/_sox
+++ b/src/_sox
@@ -1,0 +1,21 @@
+#compdef sox
+# ------------------------------------------------------------------------------
+#
+# Description
+# -----------
+#  Completion script for the sox command (from SoX)
+#  (http://sox.sourceforge.net/)
+#
+# Authors
+# -------
+#
+#  * Alexander F. Rødseth <xyproto@archlinux.org>
+#
+# ------------------------------------------------------------------------------
+
+local curcontext="$curcontext" state line
+local -i ret=1
+
+_arguments -s -S -C   '(-h --help)'{-h,--help}'[display help text]'   '(-V --version)'{-V,--version}'[display version information]'   '(-D --no-dither)'{-D,--no-dither}"[don't dither automatically]"   '(-G --guard)'{-G,--guard}'[use temporary files to guard against clipping]'   '(-m --combine=)'{-m,--combine=}'[combine input files]:method:(mix merge concatenate)'   '(-t --type=)'{-t,--type=}'[specify file type]:file type:_files'   '(-r --rate=)'{-r,--rate=}'[set sample rate]:rate'   '(-c --channels=)'{-c,--channels=}'[specify the number of channels]:channels'   '(-b --bits=)'{-b,--bits=}'[set encoded sample size in bits]:bits'   '(-e --encoding=)'{-e,--encoding=}'[set encoding]:encoding:(signed-integer unsigned-integer floating-point mu-law a-law)'   '(-p --sox-pipe)'{-p,--sox-pipe}'[use SoX pipe]'   '(-q --no-show-progress)'{-q,--no-show-progress}'[run in quiet mode]'   '*:filename:_files -g "*.wav *.mp3 *.flac *.ogg *.aiff"' && ret=0
+
+return ret

--- a/src/_soxi
+++ b/src/_soxi
@@ -1,0 +1,21 @@
+#compdef soxi
+# ------------------------------------------------------------------------------
+#
+# Description
+# -----------
+#  Completion script for the soxi command (from SoX)
+#  (http://sox.sourceforge.net/)
+#
+# Authors
+# -------
+#
+#  * Alexander F. Rødseth <xyproto@archlinux.org>
+#
+# ------------------------------------------------------------------------------
+
+local curcontext="$curcontext" state line
+local -i ret=1
+
+_arguments -s -S -C   '(-h --help)'{-h,--help}'[display help text]'   '(-V --version)'{-V,--version}'[display version information]'   '*:filename:_files -g "*.wav *.mp3 *.flac *.ogg *.aiff"' && ret=0
+
+return ret


### PR DESCRIPTION
- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [x] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.

`sox` is a collection of executables and libraries that has been in Debian since 1997. It has also been in Arch Linux for at least 10 years (probably longer). It is available for most (all?) Linux distros.

I would argue that `sox` is more well known, and has more installations, than "the Play Framework for Java and Scala".

This PR proposes to replace `_play` (for "The Play Framework") with one for the `play` executable that comes with `sox`, and also add completions for `sox`, `soxi` and `rec`.

