### PR TITLE
Update TypeScript completion from 5.6 to 5.8

### DIFF
--- a/src/_tsc
+++ b/src/_tsc
@@ -189,8 +189,8 @@ local -a opts=(
   '--synchronousWatchDirectory[Synchronously call callbacks and update the state of directory watchers on platforms]'
   '--excludeDirectories[Remove a list of directories from the watch process]:dirs:_files -/'
   "--excludeFiles[Remove a list of files from the watch mode's processing]:files:_files"
-  "--libReplacement[Enable library replacement]:boolean:(true false)"
-  "--erasableSyntaxOnly[Ensures that runtime constructs which are not part of ECMAScript are not allowed]:boolean:(true false)"
+  "--libReplacement[Enable library replacement]"
+  "--erasableSyntaxOnly[Ensures that runtime constructs which are not part of ECMAScript are not allowed]"
   '*:: :_files' \
 )
 

--- a/src/_tsc
+++ b/src/_tsc
@@ -24,7 +24,7 @@
 # Description
 # -----------
 #
-#  Completion script for tsc v5.6.3. (https://www.typescriptlang.org/)
+#  Completion script for tsc v5.8.2. (https://www.typescriptlang.org/)
 #
 # ------------------------------------------------------------------------------
 # Authors
@@ -35,8 +35,8 @@
 # ------------------------------------------------------------------------------
 
 local -a module_types=(
-  none commonjs amd umd system es6/es2015 es2020 es2022 esnext node16 nodenext preserve
-)
+  none commonjs amd umd system es6/es2015 es2020 es2022 esnext node16 node18 nodenext preserve
+) 
 
 local -a bundle_libraries=(
   es5 es6/es2015 es7/es2016 es2017 es2018 es2019 es2020 es2021 es2022
@@ -189,6 +189,8 @@ local -a opts=(
   '--synchronousWatchDirectory[Synchronously call callbacks and update the state of directory watchers on platforms]'
   '--excludeDirectories[Remove a list of directories from the watch process]:dirs:_files -/'
   "--excludeFiles[Remove a list of files from the watch mode's processing]:files:_files"
+  "--libReplacement[Enable library replacement]:boolean:(true false)"
+  "--erasableSyntaxOnly[Ensures that runtime constructs which are not part of ECMAScript are not allowed]:boolean:(true false)"
   '*:: :_files' \
 )
 

--- a/src/_tsc
+++ b/src/_tsc
@@ -40,7 +40,7 @@ local -a module_types=(
 
 local -a bundle_libraries=(
   es5 es6/es2015 es7/es2016 es2017 es2018 es2019 es2020 es2021 es2022
-  es2023 esnext dom dom.iterable dom.asynciterable webworker
+  es2023 es2024 esnext dom dom.iterable dom.asynciterable webworker
   webworker.importscripts webworker.iterable webworker.asynciterable
   scripthost es2015.core es2015.collection es2015.generator
   es2015.iterable es2015.promise es2015.proxy es2015.reflect
@@ -62,7 +62,7 @@ local -a bundle_libraries=(
 )
 
 local -a targets=(
-  es5 es6/es2015 es2016 es2017 es2018 es2019 es2020 es2021 es2022 es2023 esnext
+  es5 es6/es2015 es2016 es2017 es2018 es2019 es2020 es2021 es2022 es2023 es2024 esnext
 )
 
 local -a watch_modes=(


### PR DESCRIPTION
- [x] This compdef is not already available in zsh.
- [x] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [x] This is a finished work.
- [x] It has a header containing authors, status and origin of the script.
- [x] It has a license header or I accept that it will be licensed under the terms of the Zsh license.

## Changes

### 5.7

- Added targets `es2024` for the `--lib` and `--target` options.

### 5.8

- Added `--libReplacement` and `--erasableSyntaxOnly` options.
- Added `node18` target for the `--module` option. 

Best regards 