### PR TITLE
Update README.md - Zsh rebuilding the completion cache twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Add `zinit light zsh-users/zsh-completions` to your `~/.zshrc`.
 
         rm -f ~/.zcompdump; compinit
 
+Second Solution:
+zsh-completions as a plugin, they suggest manually adding its source directory to fpath before sourcing oh-my-zsh.sh.
+This ensures Zsh loads the completion files only once, improving performance.
+Recommended Fix:
+Instead of the existing method, they propose adding this line:
+
+fpath=($ZSH/custom/plugins/zsh-completions/src $fpath)
+
 ### Contributing
 
 Contributions are welcome, see [CONTRIBUTING](https://github.com/zsh-users/zsh-completions/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
Zsh rebuilding the completion cache twice

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [ ] This compdef is not already available in zsh.
- [ ] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [ ] This is a finished work.
- [ ] It has a header containing authors, status and origin of the script.
- [ ] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
