### PR TITLE
Fix [virtualbox][vboxmanage controlvm] subcommand completion order an…

### DIFF
--- a/src/_virtualbox
+++ b/src/_virtualbox
@@ -345,10 +345,10 @@ _vboxmanage() {
             ':machine:_vboxmachines'
           ;;
         (controlvm)
-          local -a subcommands=(${(@f)"$(vboxmanage $words[1] | perl -wln -e 'm{^\s+([a-z][a-z-]+)} and print $1')"})
+          local -a subcommands=(${(@f)"$(vboxmanage $words[1] | perl -wln -e 'm{VBoxManage controlvm.*?\s+([a-z][a-z-]+)(?:\s|$)} and print $1')"})
           _arguments \
-            '1:commands:'"($subcommands)" \
-            ':machine:_vboxmachines'
+            '1:machine:_vboxmachines' \
+            '2:commands:'"($subcommands)"
           ;;
       esac
       ;;


### PR DESCRIPTION
…d regex are incorrect

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [ ] This compdef is not already available in zsh.
- [ ] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [ ] This is a finished work.
- [ ] It has a header containing authors, status and origin of the script.
- [ ] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
