### PR TITLE
fix yarn run completions

### DIFF
--- a/src/_yarn
+++ b/src/_yarn
@@ -908,7 +908,7 @@ _yarn_scripts() {
   fi
 
   local -a candidates=($scripts $binaries)
-  _values 'scripts' $candidates
+  compadd -a candidates
 }
 
 _yarn "$@"


### PR DESCRIPTION
`yarn run<TAB>` doesn't show scripts that have `:` in them (e.g. `lint:js`, `test:e2e`), which is a popular pattern. this change fixes that.

<!-- Thank you so much for your PR! -->
<!-- Please provide a general summary of your changes in the title above. -->
<!-- If submitting a new compdef, please check it is compliant with our contributing guidelines and tick the boxes: -->

- [ ] This compdef is not already available in zsh.
- [ ] This compdef is not already available in their original project.
- [ ] I am the original author, or I have authorization to submit this work.
- [ ] This is a finished work.
- [ ] It has a header containing authors, status and origin of the script.
- [ ] It has a license header or I accept that it will be licensed under the terms of the Zsh license.
