### PR TITLE
docs: clarify _regex_arguments example explanation (#1106)

### DIFF
--- a/zsh-completions-howto.org
+++ b/zsh-completions-howto.org
@@ -295,8 +295,10 @@ _regex_arguments _cmd /$'[^\0]##\0'/ \( /$'word1(a|b|c)\0'/ ':word:first word:(w
    '|' /$'word22(a|b|c)\0'/ ':word:second word:(word22a word22b word22c)' \) \)
 _cmd "$@"
 #+END_SRC
-in this case the first word can be word1 or word11 followed by an a, b or c, and if the first word contains 11 then a second
-word is allowed which can be word2 or word22 followed by and a, b, or c.
+In this example, the command itself is matched first (any non-empty word). The first argument
+can be either =word1(a|b|c)= or =word11(a|b|c)=. If the first argument matches the =word11=
+variant, a second argument becomes available, which can be either =word2(a|b|c)= or
+=word22(a|b|c)=.
 
 If this sounds too complicated a much simpler alternative is to use the _regex_words function for creating
 specifications for _regex_arguments.


### PR DESCRIPTION
Fixes #1106

The explanation paragraph below the `_regex_arguments` example did not
accurately describe the branching structure shown in the code.

The original text omitted the initial command pattern and did not make
clear that the second argument is only available when the first argument
matches the `word11` variant.

Rewrote the paragraph to match the example exactly.